### PR TITLE
Enhance README and add license and copyright headers

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2025] [Tarek Bohdima]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # ConsultMe
 
 [![Android CI](https://github.com/Tarek-Bohdima/ConsultMe/actions/workflows/android_ci.yml/badge.svg)](https://github.com/Tarek-Bohdima/ConsultMe/actions/workflows/android_ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![Platform](https://img.shields.io/badge/platform-android-green.svg)
+![Min API](https://img.shields.io/badge/Min%20API-25-purple)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
 
 **ConsultMe** is a template project for Jetpack Compose applications, featuring integrated tools for code quality and automation. It includes:
 
@@ -10,26 +15,39 @@
 
 ## Features
 
-- Fully configured for Jetpack Compose
-- Code quality tools included and pre-configured
-- Acts as a template 
-- 100% Kotlin codebase
+- Fully configured for Jetpack Compose and a multi-module architecture.
+- Code quality tools included and pre-configured.
+- 100% Kotlin codebase, using Coroutines and Flow.
+- Dependency injection with Hilt.
 
 ## Getting Started
 
-1. Clone this repository:
-   ```bash
-   git clone https://github.com/Tarek-Bohdima/ConsultMe.git
-   ```
-2. Open in Android Studio
-3. Sync Gradle and run the project
+Do not clone this repository directly. The recommended way to use this template is to create your own repository from it.
+
+1.  Click the **Use this template** button on the main repository page and select **Create a new repository**.
+2.  Give your new project a name and description. This creates a completely new and independent repository.
+3.  Clone your new repository to your local machine and open it in Android Studio.
+4.  Follow the instructions in the **"How to Rename and Refactor"** section below to customize it for your project.
+
+> **Note on Forking:** If your intention is to contribute changes back to this template, you should fork the repository instead.
+
+## How to Rename and Refactor
+
+After creating your new repository, you need to update the project's identity. Use Android Studio's **Refactor > Rename** tool for safety and reliability.
+
+1.  **Project Name:** In `settings.gradle.kts`, change `rootProject.name`.
+2.  **Application ID & Namespaces:** In `app/build.gradle.kts` and the `build.gradle.kts` of each library module, change the `namespace` and `applicationId` from `com.thecompany.consultme` to your new ID.
+3.  **Package Name:** Use Android Studio's refactoring tool to rename the `com.thecompany.consultme` package.
+4.  **App Display Name:** In `app/src/main/res/values/strings.xml`, change the `app_name` string.
+5.  **Update License File:** Open the `LICENSE` file in the root directory and replace `[year]` and `[your name or organization]` with your own information.
+6.  **Clean Up:** Delete the example code in the `:feature-chat` module to start building your own features and fix MainActivity in app module accordingly.
 
 ## Code Quality
 
-- **Spotless**: Ensures consistent code formatting
-- **Detect**: Finds common code issues
-- **Lint**: Enforces Kotlin and Compose best practices
+- **Spotless**: Ensures consistent code formatting.
+- **Detect**: Finds common code issues.
+- **Lint**: Enforces Kotlin and Compose best practices.
 
 ## License
 
-Specify your license here.
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.

--- a/app/src/androidTest/java/com/thecompany/consultme/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/thecompany/consultme/ExampleInstrumentedTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/main/java/com/thecompany/consultme/MainActivity.kt
+++ b/app/src/main/java/com/thecompany/consultme/MainActivity.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme
 
 import android.os.Bundle
@@ -7,10 +8,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.thecompany.consultme.feature.chat.ui.ChatScreen
 import com.thecompany.consultme.ui.theme.ConsultMeTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -22,28 +23,17 @@ class MainActivity : ComponentActivity() {
         setContent {
             ConsultMeTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding),
-                    )
+                    ChatScreen(modifier = Modifier.padding(innerPadding))
                 }
             }
         }
     }
 }
 
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier,
-    )
-}
-
 @Preview(showBackground = true)
 @Composable
 fun GreetingPreview() {
     ConsultMeTheme {
-        Greeting("Android")
+        ChatScreen()
     }
 }

--- a/app/src/main/java/com/thecompany/consultme/ui/theme/Color.kt
+++ b/app/src/main/java/com/thecompany/consultme/ui/theme/Color.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.ui.theme
 
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/com/thecompany/consultme/ui/theme/Theme.kt
+++ b/app/src/main/java/com/thecompany/consultme/ui/theme/Theme.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.ui.theme
 
 import android.os.Build

--- a/app/src/main/java/com/thecompany/consultme/ui/theme/Type.kt
+++ b/app/src/main/java/com/thecompany/consultme/ui/theme/Type.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.ui.theme
 
 import androidx.compose.material3.Typography

--- a/app/src/test/java/com/thecompany/consultme/ExampleUnitTest.kt
+++ b/app/src/test/java/com/thecompany/consultme/ExampleUnitTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme
 
 import org.junit.Assert.assertEquals

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,32 @@ subprojects {
         kotlin {
             target("**/*.kt")
             targetExclude("**/camera/viewfinder/**")
+
+            // Define and apply the license header for Kotlin files
+            // This is the robust, correct way to apply the license header.
+            // It places the header AFTER the package declaration.
+            licenseHeader(
+                """
+                // Copyright ${'$'}YEAR MyCompany
+                """.trimIndent(),
+                "package " // The delimiter tells Spotless to look for the line starting with "package "
+            )
+
             ktlint(libs.ktlint.get().version)
         }
         kotlinGradle {
+            target("*.gradle.kts")
+
+            // Define and apply the license header for Gradle files
+            // For Gradle files, there's no package declaration, so we don't need a delimiter.
+            // It will be placed at the top of the file.
+            licenseHeader(
+                """
+                // Copyright ${'$'}YEAR MyCompany
+                """.trimIndent(),
+                  "/*"
+            )
+
             ktlint(libs.ktlint.get().version)
         }
     }

--- a/core-data/src/androidTest/java/com/thecompany/consultme/core/data/ExampleInstrumentedTest.kt
+++ b/core-data/src/androidTest/java/com/thecompany/consultme/core/data/ExampleInstrumentedTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.core.data
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/core-data/src/test/java/com/thecompany/consultme/core/data/ExampleUnitTest.kt
+++ b/core-data/src/test/java/com/thecompany/consultme/core/data/ExampleUnitTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.core.data
 
 import org.junit.Assert.assertEquals

--- a/core-database/src/androidTest/java/com/thecompany/consultme/core/database/ExampleInstrumentedTest.kt
+++ b/core-database/src/androidTest/java/com/thecompany/consultme/core/database/ExampleInstrumentedTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.core.database
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/core-database/src/test/java/com/thecompany/consultme/core/database/ExampleUnitTest.kt
+++ b/core-database/src/test/java/com/thecompany/consultme/core/database/ExampleUnitTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.core.database
 
 import org.junit.Assert.assertEquals

--- a/core-testing/src/androidTest/java/com/thecompany/consultme/core/testing/ExampleInstrumentedTest.kt
+++ b/core-testing/src/androidTest/java/com/thecompany/consultme/core/testing/ExampleInstrumentedTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.core.testing
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/core-testing/src/main/java/com/thecompany/consultme/core/testing/HiltTestRunner.kt
+++ b/core-testing/src/main/java/com/thecompany/consultme/core/testing/HiltTestRunner.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.core.testing
 
 import android.app.Application

--- a/core-testing/src/test/java/com/thecompany/consultme/core/testing/ExampleUnitTest.kt
+++ b/core-testing/src/test/java/com/thecompany/consultme/core/testing/ExampleUnitTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.core.testing
 
 import org.junit.Assert.assertEquals

--- a/core-ui/src/androidTest/java/com/thecompany/consultme/core/ui/ExampleInstrumentedTest.kt
+++ b/core-ui/src/androidTest/java/com/thecompany/consultme/core/ui/ExampleInstrumentedTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.core.ui
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/core-ui/src/test/java/com/thecompany/consultme/core/ui/ExampleUnitTest.kt
+++ b/core-ui/src/test/java/com/thecompany/consultme/core/ui/ExampleUnitTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.core.ui
 
 import org.junit.Assert.assertEquals

--- a/feature-chat/src/androidTest/java/com/thecompany/consultme/feature/chat/ui/ExampleInstrumentedTest.kt
+++ b/feature-chat/src/androidTest/java/com/thecompany/consultme/feature/chat/ui/ExampleInstrumentedTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.feature.chat.ui
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/feature-chat/src/main/java/com/thecompany/consultme/feature/chat/ui/ChatScreen.kt
+++ b/feature-chat/src/main/java/com/thecompany/consultme/feature/chat/ui/ChatScreen.kt
@@ -1,0 +1,26 @@
+// Copyright 2025 MyCompany
+package com.thecompany.consultme.feature.chat.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ChatScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = "Welcome to the Chat Feature!")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ChatScreenPreview() {
+    ChatScreen()
+}

--- a/feature-chat/src/test/java/com/thecompany/consultme/feature/chat/ui/ExampleUnitTest.kt
+++ b/feature-chat/src/test/java/com/thecompany/consultme/feature/chat/ui/ExampleUnitTest.kt
@@ -1,3 +1,4 @@
+// Copyright 2025 MyCompany
 package com.thecompany.consultme.feature.chat.ui
 
 import org.junit.Assert.assertEquals


### PR DESCRIPTION
This commit introduces several improvements:

- Updated the README.md with more detailed instructions on how to use the template, including renaming and refactoring steps.
- Added a `LICENSE.md` file with the MIT License.
- Configured Spotless to automatically add copyright headers to all Kotlin and Gradle files.
- Added a simple `ChatScreen.kt` composable in the `feature-chat` module.
- Updated `MainActivity.kt` to display the `ChatScreen`.