### PR TITLE
feat: Add Dependabot configuration for Gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle" # For Android dependencies
+    directory: "/" # Location of your build.gradle files
+    schedule:
+      interval: "weekly" # Or "daily" / "monthly"
+    open-pull-requests-limit: 10 # Manage PR volume
+    reviewers:
+      - "Tarek-Bohdima" # Optional: assign reviewers
+    assignees:
+      - "Tarek-Bohdima" # Optional: assign someone
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
This commit introduces a Dependabot configuration file (`dependabot.yml`) to automate dependency updates for the Gradle package ecosystem.

The configuration specifies:
- Weekly checks for updates.
- A limit of 10 open pull requests.
- Assigns "Tarek-Bohdima" as reviewer and assignee for Dependabot PRs.
- Uses a commit message prefix of "chore" and includes the scope.