### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -1,4 +1,6 @@
 name: Android CI
+permissions:
+  contents: read
 
 on:
   pull_request: # Triggers on any pull request


### PR DESCRIPTION
Potential fix for [https://github.com/Tarek-Bohdima/ConsultMe/security/code-scanning/1](https://github.com/Tarek-Bohdima/ConsultMe/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN to the minimum required. Since the workflow only needs to read repository contents (for checkout and running tests), set `permissions: contents: read` at the workflow root, just below the `name:` and before the `on:` block. This ensures all jobs in the workflow inherit these minimal permissions unless overridden. No other changes are needed, and this will not affect existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
