### PR TITLE
refactor(deps): Consolidate test dependencies into bundles

### DIFF
--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -69,31 +69,16 @@ android {
 }
 
 dependencies {
-    // Dependencies required by this module's own code (e.g., HiltTestRunner which needs AndroidJUnitRunner)
-    implementation(libs.androidx.test.runner)
+    api(libs.bundles.test.unit)
 
-    // Common test dependencies exposed to other modules using 'api'
+    api(libs.androidx.test.core)
+    api(libs.androidx.test.ext.junit)
+    api(libs.androidx.test.runner)
+    api(libs.androidx.espresso.core)
+    api(libs.hilt.android.testing)
 
-    // Core Android & JUnit testing libraries
-    api(libs.junit) // For JUnit 4
-    api(libs.androidx.test.core) // For ApplicationProvider, ActivityScenario, etc.
-    api(libs.androidx.test.ext.junit) // For AndroidX Test - JUnit4 integration
-    api(libs.androidx.test.runner) // For AndroidJUnitRunner (also useful for consumers)
-    api(libs.androidx.espresso.core) // For Espresso UI testing
-
-    // Hilt for testing
-    api(libs.hilt.android.testing) // For HiltTestApplication, HiltAndroidRule, @HiltAndroidTest
-
-    // Coroutines testing
-    api(libs.kotlinx.coroutines.test) // For TestCoroutineDispatcher, runTest, etc.
-
-    // MockK (for Kotlin-friendly mocking in unit tests)
-    api(libs.mockk.core)
-    api(libs.mockk.android) // For using MockK in AndroidTest
-
-    // Turbine (for testing Kotlin Flows)
-    api(libs.turbine)
-
-    // Truth (for fluent assertions)
-    api(libs.truth)
+    api(libs.mockk.android) {
+        exclude(group = "io.mockk", module = "mockk-agent-jvm")
+        exclude(group = "io.mockk", module = "mockk-agent")
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,10 @@ turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine
 # Truth (for fluent assertions)
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 
+[bundles]
+test-unit = ["junit", "mockk-core", "kotlinx-coroutines-test", "turbine", "truth"]
+test-android = ["androidx-test-core", "androidx-test-ext-junit", "androidx-test-runner", "androidx-espresso-core", "mockk-android", "hilt-android-testing"]
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
Consolidates common unit and Android test dependencies into `test-unit` and `test-android` version catalog bundles.

This change simplifies dependency declarations in `build.gradle.kts` files by replacing individual test library declarations with the new bundles.

Specific changes:
- `core-testing/build.gradle.kts`: Replaces multiple `api` dependency declarations with `api(libs.bundles.test.unit)` and individual `api` calls for Android-specific testing libraries.
- `gradle/libs.versions.toml`: Introduces `test-unit` and `test-android` bundles to group related testing libraries.
- Adds exclusions for `mockk-agent-jvm` and `mockk-agent` from the `mockk-android` dependency to resolve potential conflicts.