### PR TITLE
chore(deps): widen kotlin ignore to >=2.3.20 (context-receivers blocker)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,12 +23,14 @@ updates:
       # Hilt 2.59+ requires AGP 9. Hold at 2.58.x until the AGP 9 migration.
       - dependency-name: "com.google.dagger.hilt.android"
         versions: [">=2.59"]
-      # Kotlin 2.3.20 produced compilation errors in core-testing/feature-chat.
-      # Hold this specific version; later patch versions can be retried.
+      # Kotlin 2.3.20+ promotes -Xcontext-receivers from warning to a hard
+      # error in release variants, breaking compileReleaseKotlin in
+      # :core-testing and the feature module. Hold until the migration to
+      # -Xcontext-parameters is done (tracked in docs/IMPROVEMENT_PLAN.md).
       - dependency-name: "org.jetbrains.kotlin.android"
-        versions: ["2.3.20"]
+        versions: [">=2.3.20"]
       - dependency-name: "org.jetbrains.kotlin.plugin.compose"
-        versions: ["2.3.20"]
+        versions: [">=2.3.20"]
 
     # Group related dependency updates into single pull requests
     groups:

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -91,11 +91,11 @@ Currently silenced in `.github/dependabot.yml`. Each is its own dedicated PR, no
 
 - **AGP 8.x → 9.x.** Drops the `kotlin-android` plugin requirement and forces Gradle ≥ 9.4. Touches every module's plugin block. Requires removing `alias(libs.plugins.kotlin.android)` and verifying Compose/KSP/Hilt all play nicely with AGP 9's bundled Kotlin support.
 - **Hilt 2.59+.** Hard-requires AGP 9; do this in the same PR or a follow-up to the AGP 9 migration.
-- **Kotlin 2.3.20.** Currently produces compilation errors in `:core-testing` and `:feature-example`. Investigate whether it's a kapt/KSP processor mismatch or a real source incompatibility before unpinning.
+- **Kotlin 2.3.20+.** Promotes `-Xcontext-receivers` from a warning to a hard error in release variants — `compileReleaseKotlin` fails in `:core-testing` and the feature module. Both 2.3.20 and 2.3.21 hit this. Unpinning is gated on the `-Xcontext-receivers` → `-Xcontext-parameters` migration below.
 
 ## Known follow-ups not yet phased
 
-- **`-Xcontext-receivers` is deprecated** (every module sets this in `freeCompilerArgs`). Kotlin compiler warns: replace with `-Xcontext-parameters` and migrate to the new syntax. Will become an error. Worth a one-shot PR — the migration is mechanical, but worth verifying nothing in Compose/Hilt-generated code uses receivers.
+- **`-Xcontext-receivers` is deprecated** (every module sets this in `freeCompilerArgs`). Kotlin compiler warns: replace with `-Xcontext-parameters` and migrate to the new syntax. Already a hard error on Kotlin 2.3.20+ release variants — **this migration is what unblocks the Kotlin 2.3.20+ pin in `dependabot.yml`**. The migration is mechanical, but worth verifying nothing in Compose/Hilt-generated code uses receivers.
 - **KSP `2.3.4` lags Kotlin `2.3.10`.** Dependabot will likely propose a bump on the next run; let it.
 
 ## Quality bets to consider (no phase yet)


### PR DESCRIPTION
## Summary
- Widens the kotlin plugin ignores in `.github/dependabot.yml` from `["2.3.20"]` to `[">=2.3.20"]` for both `org.jetbrains.kotlin.android` and `org.jetbrains.kotlin.plugin.compose`.
- Updates `docs/IMPROVEMENT_PLAN.md` to record the actual root cause (Kotlin 2.3.20+ promotes `-Xcontext-receivers` from a warning to a hard error in release variants, breaking `compileReleaseKotlin` in `:core-testing` and the feature module) and link the unpinning to the `-Xcontext-receivers` → `-Xcontext-parameters` migration already tracked in "Known follow-ups."

## Why
PR #87 (kotlin 2.3.20) and PR #95 (kotlin 2.3.21) both failed `build_and_test` with the same `compileReleaseKotlin` error. Enumerating each patch would mean reopening this every dependabot run; widening to `>=2.3.20` keeps it pinned until the migration is actually done.

## Test plan
- [x] No code changes; only `.github/dependabot.yml` and `docs/IMPROVEMENT_PLAN.md` updated.
- [ ] CI must pass (no behavior changes expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)