### PR TITLE
chore: sync .idea/gradle.xml with feature-example rename

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,7 +14,7 @@
             <option value="$PROJECT_DIR$/core-database" />
             <option value="$PROJECT_DIR$/core-testing" />
             <option value="$PROJECT_DIR$/core-ui" />
-            <option value="$PROJECT_DIR$/feature-chat" />
+            <option value="$PROJECT_DIR$/feature-example" />
           </set>
         </option>
       </GradleProjectSettings>


### PR DESCRIPTION
## Summary
- One-line update to `.idea/gradle.xml`: replaces the stale `\$PROJECT_DIR\$/feature-chat` reference with `\$PROJECT_DIR\$/feature-example`.

## Why
PR #97 renamed `:feature-chat` → `:feature-example` everywhere except this IDE config. Android Studio rewrites the file on the next project sync; this just lands the IDE-side update in version control so future contributors don't see the same drift on first open.

The `.gitignore` policy explicitly tracks `.idea/gradle.xml` (line 25, `!.idea/gradle.xml`) for team consistency.

## Test plan
- [x] No code changes; only `.idea/gradle.xml` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)