### PR TITLE
build: Phase 1 — convention plugins (build-logic/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@
 # Gradle build system files and caches
 .gradle/
 /build/
+# Per-module Gradle build directories (modules + build-logic).
+**/build/
 
 # Avoid ignoring Gradle wrapper jar file (as .jar files are usually ignored below)
 !gradle/wrapper/gradle-wrapper.jar

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,11 @@ Lint baselines (`<module>/lint-baseline.xml`) exist per module — regenerate wi
 ## Conventions enforced by tooling
 
 - **License header**: Spotless (configured in root `build.gradle.kts`) requires `// Copyright $YEAR MyCompany` on every `.kt` and `.gradle.kts` file. Placement is delimiter-driven: above the `package` line for Kotlin, above the first `/*` for Gradle Kotlin scripts. New files without the header fail `spotlessCheck`. The "MyCompany" / `$YEAR` literals get rewritten by `spotlessApply`.
-- **Toolchain**: Every module sets `jvmToolchain(17)`, JVM target 17, and `freeCompilerArgs = ["-Xcontext-receivers"]`. Match this when adding modules.
-- **DI**: Hilt + KSP. `kapt` is intentionally left commented out across build scripts — use `ksp(libs.hilt.compiler)`. Modules that need DI must apply both `libs.plugins.hilt.gradle` and `libs.plugins.ksp` (see `:core-data` for the canonical pattern).
-- **Compose**: BOM-managed (`libs.androidx.compose.bom`). Library modules disable `buildFeatures.compose` unless they actually emit composables. `buildConfig`, `aidl`, `renderScript`, `shaders` are turned off everywhere.
-- **SDKs**: `compileSdk = 36`, `targetSdk = 36`, `minSdk = 25`.
+- **Convention plugins**: Module build scripts compose plugins from `build-logic/` instead of redeclaring AGP/Kotlin/JVM/lint config. Available: `consultme.android.application`, `consultme.android.library`, `consultme.android.compose`, `consultme.android.hilt`. Shared helpers live in `build-logic/convention/src/main/kotlin/com/thecompany/consultme/buildlogic/AndroidExtensions.kt` — extend those rather than duplicating config in module scripts.
+- **Toolchain**: `jvmToolchain(17)`, JVM target 17, `freeCompilerArgs = ["-Xcontext-receivers"]` — set by the convention plugins.
+- **DI**: Hilt + KSP, applied via `consultme.android.hilt`. The convention adds `hilt-android` impl + `hilt-compiler` ksp; don't redeclare them per module.
+- **Compose**: BOM-managed via `consultme.android.compose` (Compose BOM + ui/graphics/tooling-preview/material3). The convention enables `buildFeatures.compose`. `buildConfig`, `aidl`, `renderScript`, `shaders` are turned off everywhere by the library/application conventions.
+- **SDKs**: `compileSdk = 36`, `targetSdk = 36`, `minSdk = 25` (set by the conventions).
 
 ## Dependency management
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,81 +1,27 @@
 // Copyright 2025 MyCompany
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.hilt.gradle)
-    alias(libs.plugins.compose.compiler)
-}
-
-hilt {
-    enableAggregatingTask = true
-}
-
-kotlin {
-    jvmToolchain(17)
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        freeCompilerArgs.set(listOf("-Xcontext-receivers"))
-    }
+    id("consultme.android.application")
+    id("consultme.android.compose")
+    id("consultme.android.hilt")
 }
 
 android {
     namespace = "com.thecompany.consultme"
-    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.thecompany.consultme"
-        minSdk = 25
-        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
-
-        testInstrumentationRunner = "com.thecompany.consultme.core.testing.HiltTestRunner"
 
         vectorDrawables {
             useSupportLibrary = true
         }
     }
 
-    buildTypes {
-        getByName("release") {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    buildFeatures {
-        compose = true
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
-    }
-
-    lint {
-        baseline = file("lint-baseline.xml")
-        quiet = true
-        checkAllWarnings = true
-        warningsAsErrors = false
-        textReport = true
-        htmlReport = true
-        xmlReport = false
-        checkReleaseBuilds = true
-        abortOnError = true
-        checkDependencies = true
     }
 }
 
@@ -87,26 +33,11 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
 
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.hilt.navigation.compose)
 
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
-
     testImplementation(project(":core-testing"))
     androidTestImplementation(project(":core-testing"))
-
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-
-    debugImplementation(libs.androidx.compose.ui.tooling)
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,22 @@
+// Copyright 2026 MyCompany
+plugins {
+    `kotlin-dsl`
+}
+
+group = "com.thecompany.consultme.buildlogic"
+
+kotlin {
+    jvmToolchain(17)
+}
+
+dependencies {
+    compileOnly(libs.android.gradle.plugin)
+    compileOnly(libs.kotlin.gradle.plugin)
+    compileOnly(libs.compose.compiler.gradle.plugin)
+    compileOnly(libs.hilt.gradle.plugin)
+    compileOnly(libs.ksp.gradle.plugin)
+
+    // Expose the `libs` version-catalog accessor inside precompiled script plugins.
+    // See https://github.com/gradle/gradle/issues/15383
+    compileOnly(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
+}

--- a/build-logic/convention/src/main/kotlin/com/thecompany/consultme/buildlogic/AndroidExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/thecompany/consultme/buildlogic/AndroidExtensions.kt
@@ -1,0 +1,53 @@
+// Copyright 2026 MyCompany
+package com.thecompany.consultme.buildlogic
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+
+internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, *, *, *, *, *>) {
+    commonExtension.apply {
+        compileSdk = 36
+        defaultConfig.minSdk = 25
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
+        }
+    }
+    extensions.configure<KotlinAndroidProjectExtension> {
+        jvmToolchain(17)
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+            freeCompilerArgs.set(listOf("-Xcontext-receivers"))
+        }
+    }
+}
+
+internal fun CommonExtension<*, *, *, *, *, *>.configureBuildFeatures() {
+    // `compose` is managed by the dedicated `consultme.android.compose` plugin
+    // so that applying it before/after this convention is order-independent.
+    buildFeatures.apply {
+        aidl = false
+        buildConfig = false
+        renderScript = false
+        shaders = false
+    }
+}
+
+internal fun Project.configureLint(commonExtension: CommonExtension<*, *, *, *, *, *>) {
+    commonExtension.lint {
+        baseline = file("lint-baseline.xml")
+        quiet = true
+        checkAllWarnings = true
+        warningsAsErrors = false
+        textReport = true
+        htmlReport = true
+        xmlReport = false
+        checkReleaseBuilds = true
+        abortOnError = true
+        checkDependencies = true
+    }
+}

--- a/build-logic/convention/src/main/kotlin/consultme.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/consultme.android.application.gradle.kts
@@ -1,0 +1,29 @@
+// Copyright 2026 MyCompany
+import com.android.build.api.dsl.ApplicationExtension
+import com.thecompany.consultme.buildlogic.configureBuildFeatures
+import com.thecompany.consultme.buildlogic.configureKotlinAndroid
+import com.thecompany.consultme.buildlogic.configureLint
+
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+extensions.configure<ApplicationExtension> {
+    configureKotlinAndroid(this)
+    defaultConfig {
+        targetSdk = 36
+        testInstrumentationRunner = "com.thecompany.consultme.core.testing.HiltTestRunner"
+    }
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+    configureBuildFeatures()
+    configureLint(this)
+}

--- a/build-logic/convention/src/main/kotlin/consultme.android.compose.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/consultme.android.compose.gradle.kts
@@ -1,0 +1,26 @@
+// Copyright 2026 MyCompany
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.accessors.dm.LibrariesForLibs
+
+plugins {
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
+val libs = the<LibrariesForLibs>()
+
+extensions.findByType<CommonExtension<*, *, *, *, *, *>>()?.apply {
+    buildFeatures.compose = true
+}
+
+dependencies {
+    val bom = libs.androidx.compose.bom
+    "implementation"(platform(bom))
+    "androidTestImplementation"(platform(bom))
+    "implementation"(libs.androidx.compose.ui)
+    "implementation"(libs.androidx.ui.graphics)
+    "implementation"(libs.androidx.compose.ui.tooling.preview)
+    "implementation"(libs.androidx.compose.material3)
+    "androidTestImplementation"(libs.androidx.compose.ui.test.junit4)
+    "debugImplementation"(libs.androidx.compose.ui.tooling)
+    "debugImplementation"(libs.androidx.compose.ui.test.manifest)
+}

--- a/build-logic/convention/src/main/kotlin/consultme.android.hilt.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/consultme.android.hilt.gradle.kts
@@ -1,0 +1,19 @@
+// Copyright 2026 MyCompany
+import dagger.hilt.android.plugin.HiltExtension
+import org.gradle.accessors.dm.LibrariesForLibs
+
+plugins {
+    id("com.google.dagger.hilt.android")
+    id("com.google.devtools.ksp")
+}
+
+val libs = the<LibrariesForLibs>()
+
+extensions.configure<HiltExtension> {
+    enableAggregatingTask = true
+}
+
+dependencies {
+    "implementation"(libs.hilt.android)
+    "ksp"(libs.hilt.compiler)
+}

--- a/build-logic/convention/src/main/kotlin/consultme.android.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/consultme.android.library.gradle.kts
@@ -1,0 +1,29 @@
+// Copyright 2026 MyCompany
+import com.android.build.gradle.LibraryExtension
+import com.thecompany.consultme.buildlogic.configureBuildFeatures
+import com.thecompany.consultme.buildlogic.configureKotlinAndroid
+import com.thecompany.consultme.buildlogic.configureLint
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+extensions.configure<LibraryExtension> {
+    configureKotlinAndroid(this)
+    defaultConfig {
+        testInstrumentationRunner = "com.thecompany.consultme.core.testing.HiltTestRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+    configureBuildFeatures()
+    configureLint(this)
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,17 @@
+// Copyright 2026 MyCompany
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -1,76 +1,17 @@
 // Copyright 2025 MyCompany
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.hilt.gradle)
-    alias(libs.plugins.ksp)
-}
-
-kotlin {
-    jvmToolchain(17)
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        freeCompilerArgs.set(listOf("-Xcontext-receivers"))
-    }
-}
-
-hilt {
-    enableAggregatingTask = true
+    id("consultme.android.library")
+    id("consultme.android.hilt")
 }
 
 android {
     namespace = "com.thecompany.consultme.core.data"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 25
-        testInstrumentationRunner = "com.thecompany.consultme.core.testing.HiltTestRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
-            )
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    buildFeatures {
-        compose = false
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    lint {
-        baseline = file("lint-baseline.xml")
-        quiet = true
-        checkAllWarnings = true
-        warningsAsErrors = false
-        textReport = true
-        htmlReport = true
-        xmlReport = false
-        checkReleaseBuilds = true
-        abortOnError = true
-        checkDependencies = true
-    }
 }
 
 dependencies {
     implementation(project(":core-database"))
 
     implementation(libs.androidx.core.ktx)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
 
     testImplementation(project(":core-testing"))
     androidTestImplementation(project(":core-testing"))

--- a/core-database/build.gradle.kts
+++ b/core-database/build.gradle.kts
@@ -1,78 +1,21 @@
 // Copyright 2025 MyCompany
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.hilt.gradle)
-    alias(libs.plugins.ksp)
-}
-
-kotlin {
-    jvmToolchain(17)
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        freeCompilerArgs.set(listOf("-Xcontext-receivers"))
-    }
-}
-
-hilt {
-    enableAggregatingTask = true
+    id("consultme.android.library")
+    id("consultme.android.hilt")
 }
 
 android {
     namespace = "com.thecompany.consultme.core.database"
-    compileSdk = 36
 
     defaultConfig {
-        minSdk = 25
-        testInstrumentationRunner = "com.thecompany.consultme.core.testing.HiltTestRunner"
-        consumerProguardFiles("consumer-rules.pro")
-
         ksp {
             arg("room.schemaLocation", "$projectDir/schemas")
         }
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
-            )
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    buildFeatures {
-        compose = false
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    lint {
-        baseline = file("lint-baseline.xml")
-        quiet = true
-        checkAllWarnings = true
-        warningsAsErrors = false
-        textReport = true
-        htmlReport = true
-        xmlReport = false
-        checkReleaseBuilds = true
-        abortOnError = true
-        checkDependencies = true
     }
 }
 
 dependencies {
     implementation(libs.androidx.core.ktx)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
 
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -1,63 +1,15 @@
-/*
- * Copyright 2025 MyCompany
- */
+// Copyright 2025 MyCompany
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-}
-
-kotlin {
-    jvmToolchain(17)
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        freeCompilerArgs.set(listOf("-Xcontext-receivers"))
-    }
+    id("consultme.android.library")
 }
 
 android {
     namespace = "com.thecompany.consultme.core.testing"
-    compileSdk = 36
 
+    // Override the convention default — :core-testing provides HiltTestRunner,
+    // so it can't depend on its own runner.
     defaultConfig {
-        minSdk = 25
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
-            )
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    buildFeatures {
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    lint {
-        baseline = file("lint-baseline.xml")
-        quiet = true
-        checkAllWarnings = true
-        warningsAsErrors = false
-        textReport = true
-        htmlReport = true
-        xmlReport = false
-        checkReleaseBuilds = true
-        abortOnError = true
-        checkDependencies = true
     }
 }
 

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -1,81 +1,16 @@
 // Copyright 2025 MyCompany
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.hilt.gradle)
-    alias(libs.plugins.compose.compiler)
-}
-
-kotlin {
-    jvmToolchain(17)
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        freeCompilerArgs.set(listOf("-Xcontext-receivers"))
-    }
-}
-
-hilt {
-    enableAggregatingTask = true
+    id("consultme.android.library")
+    id("consultme.android.compose")
+    id("consultme.android.hilt")
 }
 
 android {
     namespace = "com.thecompany.consultme.core.ui"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 25
-        testInstrumentationRunner = "com.thecompany.consultme.core.testing.HiltTestRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
-            )
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    buildFeatures {
-        compose = true
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    lint {
-        baseline = file("lint-baseline.xml")
-        quiet = true
-        checkAllWarnings = true
-        warningsAsErrors = false
-        textReport = true
-        htmlReport = true
-        xmlReport = false
-        checkReleaseBuilds = true
-        abortOnError = true
-        checkDependencies = true
-    }
 }
 
 dependencies {
     implementation(libs.androidx.core.ktx)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
 
     testImplementation(project(":core-testing"))
     androidTestImplementation(project(":core-testing"))

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -6,8 +6,8 @@ ConsultMe is a Jetpack Compose multi-module Android template. This document is t
 
 | Phase | Theme | State |
 |---|---|---|
-| 0 | Cleanup & flexibility | **In progress** (this PR) |
-| 1 | Convention plugins (`build-logic/`) | Not started |
+| 0 | Cleanup & flexibility | **Done** (#97) |
+| 1 | Convention plugins (`build-logic/`) | **Done** (this PR) |
 | 2 | Template ergonomics (bootstrap script, parameterized header) | Not started |
 | 3 | Real example tests | Not started |
 | 4 | Production-readiness (R8, CI artifacts, instrumented tests) | Not started |
@@ -17,9 +17,9 @@ Tick the table when phases land. Each phase below lists scope, rationale, and a 
 
 ---
 
-## Phase 0 — Cleanup & flexibility (this PR)
+## Phase 0 — Cleanup & flexibility (done)
 
-Goal: strip migration-era cruft and make the placeholder feature module agnostic so the template doesn't ship as "ChatApp."
+Shipped in #97. Goal was to strip migration-era cruft and make the placeholder feature module agnostic so the template doesn't ship as "ChatApp."
 
 - **Rename `:feature-chat` → `:feature-example`.** "Chat" is a domain; "example" is scaffolding intent. Touches `settings.gradle.kts`, `app/build.gradle.kts`, the module dir, the source package (`feature.chat` → `feature.example`), `ChatScreen.kt` → `ExampleScreen.kt`, the import in `MainActivity.kt`, and the README rename steps.
 - **Strip migration comments from every `build.gradle.kts`.** The `// <-- ADDED`, `// <-- ENSURED/ADDED`, `// <-- REMOVED (likely not needed)`, `// As per your other files`, etc., are artifacts from when this template was being assembled. They don't describe behavior, only history — and the template's lineage will diverge from forks anyway.
@@ -34,26 +34,29 @@ Goal: strip migration-era cruft and make the placeholder feature module agnostic
 
 Out of scope for Phase 0 (intentionally): restructuring build scripts, parameterizing the license header, ProGuard, CI changes. Those each have their own phase.
 
-## Phase 1 — Convention plugins
+## Phase 1 — Convention plugins (done)
 
-Goal: eliminate the ~70 lines of identical Gradle config in every library module so that adding a feature is a one-liner.
+Goal: eliminate the duplicated Gradle config in every module so adding a feature is a near-one-liner.
 
-Create a `build-logic/` included build with precompiled script plugins:
-- `consultme.android.application` — applies AGP-app + kotlin + ksp + hilt + compose-compiler; sets compileSdk/minSdk/JVM 17/buildFeatures defaults/lint.
-- `consultme.android.library` — same set minus app concerns; flag for `withCompose`.
-- `consultme.android.feature` — depends on `library` + Compose; auto-includes `:core-ui` and `:core-testing`.
-- `consultme.android.hilt` — applied where DI is wanted.
+Shipped as a `build-logic/` included build with four precompiled script plugins, composed per module:
 
-After this, a feature module's build script collapses to:
-```kotlin
-plugins { id("consultme.android.feature") }
-android { namespace = "com.thecompany.consultme.feature.foo" }
-```
+- `consultme.android.application` — AGP-app + kotlin + JVM 17 / `-Xcontext-receivers` + compileSdk/minSdk/lint defaults + Hilt test runner + release proguard wiring.
+- `consultme.android.library` — same scope minus app concerns + `consumerProguardFiles`.
+- `consultme.android.compose` — compose-compiler plugin + `buildFeatures.compose = true` + Compose BOM + ui/graphics/tooling-preview/material3 deps.
+- `consultme.android.hilt` — hilt-gradle + ksp plugins + `enableAggregatingTask = true` + `hilt-android` impl + `hilt-compiler` ksp.
 
-Notes for whoever picks this up:
-- Use precompiled script plugins (`build-logic/convention/src/main/kotlin/*.gradle.kts`), not `buildSrc`. `buildSrc` invalidates the entire build cache on edit; an included build doesn't.
-- Reference `gradle/libs.versions.toml` from the convention plugins via the version catalog accessor (`libs` is available).
-- Resist the urge to over-parameterize. Two or three plugins beat one mega-plugin with twelve flags.
+How modules compose them:
+- `:core-testing` — `library` only.
+- `:core-data`, `:core-database` — `library + hilt`.
+- `:core-ui`, `:feature-example` — `library + compose + hilt`.
+- `:app` — `application + compose + hilt`.
+
+A feature module's build script now reads ~20 lines: `plugins {}`, `namespace`, module-specific dependencies. Total scripts shrunk from ~530 to ~190 lines.
+
+Notes for the next contributor:
+- Plugin sources live under `build-logic/convention/src/main/kotlin/`. Shared helpers (`configureKotlinAndroid`, `configureBuildFeatures`, `configureLint`) live in `com.thecompany.consultme.buildlogic`.
+- The version catalog (`libs`) is exposed inside precompiled script plugins via the workaround documented on `build-logic/convention/build.gradle.kts` (Gradle issue #15383).
+- Resist a `feature` mega-plugin — two or three composable plugins beat one with twelve flags.
 
 ## Phase 2 — Template ergonomics
 

--- a/feature-example/build.gradle.kts
+++ b/feature-example/build.gradle.kts
@@ -1,92 +1,22 @@
 // Copyright 2025 MyCompany
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.hilt.gradle)
-    alias(libs.plugins.compose.compiler)
-}
-
-kotlin {
-    jvmToolchain(17)
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        freeCompilerArgs.set(listOf("-Xcontext-receivers"))
-    }
-}
-
-hilt {
-    enableAggregatingTask = true
+    id("consultme.android.library")
+    id("consultme.android.compose")
+    id("consultme.android.hilt")
 }
 
 android {
     namespace = "com.thecompany.consultme.feature.example"
-    compileSdk = 36
-
-    defaultConfig {
-        minSdk = 25
-        testInstrumentationRunner = "com.thecompany.consultme.core.testing.HiltTestRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro",
-            )
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    buildFeatures {
-        compose = true
-        aidl = false
-        buildConfig = false
-        renderScript = false
-        shaders = false
-    }
-
-    lint {
-        baseline = file("lint-baseline.xml")
-        quiet = true
-        checkAllWarnings = true
-        warningsAsErrors = false
-        textReport = true
-        htmlReport = true
-        xmlReport = false
-        checkReleaseBuilds = true
-        abortOnError = true
-        checkDependencies = true
-    }
 }
 
 dependencies {
     implementation(project(":core-data"))
 
     implementation(libs.androidx.core.ktx)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
 
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
-
     testImplementation(project(":core-testing"))
     androidTestImplementation(project(":core-testing"))
-
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-    debugImplementation(libs.androidx.compose.ui.tooling)
-    debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,12 @@ androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-com
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 hilt-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 
+# Plugin libraries — used by build-logic convention plugins (compileOnly).
+android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
+kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+compose-compiler-gradle-plugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
+ksp-gradle-plugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google {
             content {


### PR DESCRIPTION
## Summary
Extracts the duplicated AGP/Kotlin/JVM/lint configuration from every module into a `build-logic/` included build with four composable precompiled script plugins:

| Plugin | Scope |
|---|---|
| `consultme.android.application` | AGP-app + kotlin + JVM 17 / `-Xcontext-receivers` + compileSdk/minSdk/lint defaults + Hilt test runner + release proguard wiring |
| `consultme.android.library` | same scope minus app concerns + `consumerProguardFiles` |
| `consultme.android.compose` | compose-compiler plugin + `buildFeatures.compose` + Compose BOM + ui/material3/tooling-preview deps |
| `consultme.android.hilt` | hilt-gradle + ksp + `enableAggregatingTask` + `hilt-android` impl + `hilt-compiler` ksp |

**How modules compose them:**
- `:core-testing` → `library`
- `:core-data`, `:core-database` → `library + hilt`
- `:core-ui`, `:feature-example` → `library + compose + hilt`
- `:app` → `application + compose + hilt`

A feature module's build script now reads ~20 lines: `plugins {}`, `namespace`, module-specific dependencies. Total scripts went from **~530 → ~190 lines**; the build-logic infra adds ~150. Net **−160 lines**.

## Notes
- The `libs` version-catalog accessor isn't exposed inside precompiled script plugins by default (Gradle issue [#15383](https://github.com/gradle/gradle/issues/15383)). Worked around with the standard `files(libs.javaClass.superclass.protectionDomain.codeSource.location)` `compileOnly` dep on `build-logic/convention/build.gradle.kts`.
- The Compose `buildFeatures.compose` flag is owned exclusively by `consultme.android.compose` so plugin application order doesn't trigger AGP warnings.
- `.gitignore` widened from `/build/` to also match `**/build/`, since `build-logic/convention/build/` is now produced.

## Test plan
- [x] `./gradlew spotlessCheck` — green locally
- [x] `./gradlew detekt` — green locally
- [x] `./gradlew lintRelease` — green locally (only pre-existing `NewerVersionAvailable` warnings)
- [x] `./gradlew test` — green locally
- [x] `./gradlew assembleRelease` — green locally
- [ ] CI parity

Marks Phase 1 **Done** in `docs/IMPROVEMENT_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)