### PR TITLE
build: Phase 1 polish — type-safe project accessors + dependency bundles

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
 }
 
 dependencies {
-    implementation(project(":core-ui"))
-    implementation(project(":feature-example"))
+    implementation(projects.coreUi)
+    implementation(projects.featureExample)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
@@ -38,6 +38,6 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.hilt.navigation.compose)
 
-    testImplementation(project(":core-testing"))
-    androidTestImplementation(project(":core-testing"))
+    testImplementation(projects.coreTesting)
+    androidTestImplementation(projects.coreTesting)
 }

--- a/build-logic/convention/src/main/kotlin/consultme.android.compose.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/consultme.android.compose.gradle.kts
@@ -16,11 +16,7 @@ dependencies {
     val bom = libs.androidx.compose.bom
     "implementation"(platform(bom))
     "androidTestImplementation"(platform(bom))
-    "implementation"(libs.androidx.compose.ui)
-    "implementation"(libs.androidx.ui.graphics)
-    "implementation"(libs.androidx.compose.ui.tooling.preview)
-    "implementation"(libs.androidx.compose.material3)
+    "implementation"(libs.bundles.androidx.compose)
     "androidTestImplementation"(libs.androidx.compose.ui.test.junit4)
-    "debugImplementation"(libs.androidx.compose.ui.tooling)
-    "debugImplementation"(libs.androidx.compose.ui.test.manifest)
+    "debugImplementation"(libs.bundles.androidx.compose.debug)
 }

--- a/core-data/build.gradle.kts
+++ b/core-data/build.gradle.kts
@@ -9,10 +9,10 @@ android {
 }
 
 dependencies {
-    implementation(project(":core-database"))
+    implementation(projects.coreDatabase)
 
     implementation(libs.androidx.core.ktx)
 
-    testImplementation(project(":core-testing"))
-    androidTestImplementation(project(":core-testing"))
+    testImplementation(projects.coreTesting)
+    androidTestImplementation(projects.coreTesting)
 }

--- a/core-database/build.gradle.kts
+++ b/core-database/build.gradle.kts
@@ -21,6 +21,6 @@ dependencies {
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
 
-    testImplementation(project(":core-testing"))
-    androidTestImplementation(project(":core-testing"))
+    testImplementation(projects.coreTesting)
+    androidTestImplementation(projects.coreTesting)
 }

--- a/core-testing/build.gradle.kts
+++ b/core-testing/build.gradle.kts
@@ -18,19 +18,6 @@ dependencies {
     implementation(libs.androidx.test.runner)
 
     // Re-exported via api() so consumers don't redeclare these in every module.
-    api(libs.junit)
-    api(libs.androidx.test.core)
-    api(libs.androidx.test.ext.junit)
-    api(libs.androidx.test.runner)
-    api(libs.androidx.espresso.core)
-
-    api(libs.hilt.android.testing)
-
-    api(libs.kotlinx.coroutines.test)
-
-    api(libs.mockk.core)
-    api(libs.mockk.android)
-
-    api(libs.turbine)
-    api(libs.truth)
+    // Bundle definition lives in gradle/libs.versions.toml under [bundles].test-shared.
+    api(libs.bundles.test.shared)
 }

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -12,6 +12,6 @@ android {
 dependencies {
     implementation(libs.androidx.core.ktx)
 
-    testImplementation(project(":core-testing"))
-    androidTestImplementation(project(":core-testing"))
+    testImplementation(projects.coreTesting)
+    androidTestImplementation(projects.coreTesting)
 }

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -58,12 +58,12 @@ Notes for the next contributor:
 - The version catalog (`libs`) is exposed inside precompiled script plugins via the workaround documented on `build-logic/convention/build.gradle.kts` (Gradle issue #15383).
 - Resist a `feature` mega-plugin — two or three composable plugins beat one with twelve flags.
 
-## Phase 1 polish (small follow-ups)
+## Phase 1 polish (done)
 
-Bite-sized ergonomic wins to layer onto the convention plugins. Each is independently shippable; both come from [Modexa, "7 Gradle Kotlin DSL Tricks"](https://medium.com/@Modexa/7-gradle-kotlin-dsl-tricks-for-human-friendly-builds-68506270906f) (tricks #3 and #6).
+Two ergonomic wins layered onto the convention plugins, both from [Modexa, "7 Gradle Kotlin DSL Tricks"](https://medium.com/@Modexa/7-gradle-kotlin-dsl-tricks-for-human-friendly-builds-68506270906f) (tricks #3 and #6):
 
-- **Type-safe project accessors.** Add `enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")` in `settings.gradle.kts`, then replace `project(":core-ui")` with `projects.coreUi` etc. across module scripts. Stable since Gradle 7; gives autocomplete and refactor-safety with ~20 lines of diff.
-- **Bundles for Compose + testing dependencies.** Group the 7 Compose UI deps and the `:core-testing` `api()` list into `[bundles]` entries in `gradle/libs.versions.toml`. Shrinks `consultme.android.compose` from 9 declarations to 2 (one `implementation` bundle + the BOM `platform(...)`, which can't be bundled). Same for `core-testing`'s test-fixture re-exports.
+- **Type-safe project accessors** — `enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")` in `settings.gradle.kts`; modules now use `projects.coreUi` etc. instead of `project(":core-ui")`. Required renaming `rootProject.name` from `"Consult Me"` to `"ConsultMe"` (build identifier; user-facing app name in `strings.xml` is unchanged).
+- **Bundles for Compose + testing dependencies** — `[bundles]` entries in `gradle/libs.versions.toml`: `androidx-compose`, `androidx-compose-debug`, `test-shared`. The compose convention plugin's dep list shrunk from 10 lines to 6; `:core-testing`'s 11 `api()` lines collapsed to one `api(libs.bundles.test.shared)`. The Compose BOM stays unbundled because `platform(...)` can't wrap a bundle.
 
 ## Phase 2 — Template ergonomics
 

--- a/feature-example/build.gradle.kts
+++ b/feature-example/build.gradle.kts
@@ -10,13 +10,13 @@ android {
 }
 
 dependencies {
-    implementation(project(":core-data"))
+    implementation(projects.coreData)
 
     implementation(libs.androidx.core.ktx)
 
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
-    testImplementation(project(":core-testing"))
-    androidTestImplementation(project(":core-testing"))
+    testImplementation(projects.coreTesting)
+    androidTestImplementation(projects.coreTesting)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,34 @@ turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine
 # Truth (for fluent assertions)
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 
+[bundles]
+# Compose UI deps applied via the consultme.android.compose convention plugin.
+# `androidx.compose.bom` is intentionally NOT bundled — `platform(...)` can't be wrapped around a bundle.
+androidx-compose = [
+    "androidx-compose-ui",
+    "androidx-ui-graphics",
+    "androidx-compose-ui-tooling-preview",
+    "androidx-compose-material3",
+]
+androidx-compose-debug = [
+    "androidx-compose-ui-tooling",
+    "androidx-compose-ui-test-manifest",
+]
+# Re-exported from :core-testing via api() so consumers don't redeclare per module.
+test-shared = [
+    "junit",
+    "androidx-test-core",
+    "androidx-test-ext-junit",
+    "androidx-test-runner",
+    "androidx-espresso-core",
+    "hilt-android-testing",
+    "kotlinx-coroutines-test",
+    "mockk-core",
+    "mockk-android",
+    "turbine",
+    "truth",
+]
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,8 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
@@ -25,7 +27,7 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "Consult Me"
+rootProject.name = "ConsultMe"
 include(":app")
 include(":core-ui")
 include(":core-data")


### PR DESCRIPTION
## Summary
Two ergonomic wins that layer onto the convention plugins shipped in #101, both from [Modexa, "7 Gradle Kotlin DSL Tricks"](https://medium.com/@Modexa/7-gradle-kotlin-dsl-tricks-for-human-friendly-builds-68506270906f) (tricks #3 and #6) — they were tracked in `docs/IMPROVEMENT_PLAN.md` after #102 and are now done.

### 1. Type-safe project accessors
- `enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")` in `settings.gradle.kts`.
- Modules now use `projects.coreUi`, `projects.coreTesting`, `projects.featureExample`, etc. instead of `project(":core-ui")`.
- **Side effect:** `rootProject.name` had to be renamed from `"Consult Me"` to `"ConsultMe"` because the typesafe-accessors generator requires the project name to match `[a-zA-Z]([A-Za-z0-9\-_])*`. This is the Gradle build identifier — the human-facing app name in `app/src/main/res/values/strings.xml` is unaffected.

### 2. Dependency bundles
- New `[bundles]` entries in `gradle/libs.versions.toml`:
  - `androidx-compose` — the four Compose UI/material3/tooling-preview deps.
  - `androidx-compose-debug` — `ui-tooling` + `ui-test-manifest`.
  - `test-shared` — the 11 testing libs `:core-testing` re-exports via `api()`.
- `consultme.android.compose` plugin: dep block shrank from 10 lines to 6.
- `:core-testing/build.gradle.kts`: 11 `api(...)` lines collapsed to one `api(libs.bundles.test.shared)`.
- The Compose BOM stays unbundled — `platform(...)` can't wrap a bundle, this is a known catalog limitation.

## Test plan
- [x] `./gradlew spotlessCheck detekt lintRelease test` — green locally
- [ ] CI parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)