### PR TITLE
build: Phase 2 — template ergonomics (rename script + parameterized header)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,96 @@ Do not clone this repository directly. The recommended way to use this template 
 
 ## How to Rename and Refactor
 
-After creating your new repository, you need to update the project's identity. Use Android Studio's **Refactor > Rename** tool for safety and reliability.
+After creating your new repository, run the bootstrap script — it does the package, namespace, `applicationId`, project name, theme/application class, manifest, and `app_name` rewrites in one pass:
 
-1.  **Project Name:** In `settings.gradle.kts`, change `rootProject.name`.
-2.  **Application ID & Namespaces:** In `app/build.gradle.kts` and the `build.gradle.kts` of each library module, change the `namespace` and `applicationId` from `com.thecompany.consultme` to your new ID.
-3.  **Package Name:** Use Android Studio's refactoring tool to rename the `com.thecompany.consultme` package.
-4.  **App Display Name:** In `app/src/main/res/values/strings.xml`, change the `app_name` string.
-5.  **Update License File:** Open the `LICENSE` file in the root directory and replace `[year]` and `[your name or organization]` with your own information.
-6.  **Clean Up:** Replace the placeholder content in `:feature-example` (start with `ExampleScreen.kt`) with your real feature code, and update the corresponding import in `app/.../MainActivity.kt`. Rename the module itself (`:feature-example` → `:feature-yourname`) once you know what you're building.
-7.  **Remove Template Funding File:** Delete the `.github/FUNDING.yml` file, or replace it with your own sponsorship information.
+```bash
+python3 scripts/rename-template.py com.acme.myapp "My App Name"
+```
+
+The first argument is the new package (also used as `applicationId`). The second is the user-facing app name; its PascalCase form (`MyAppName`) becomes `rootProject.name`, the theme name, and the `Application` class name. The four convention plugin IDs under `build-logic/` are also rewritten (`consultme.android.*` → `myappname.android.*`). Re-running with the same arguments is a no-op.
+
+After the script completes, finish the bootstrap by hand:
+
+1. **License header company name:** open `gradle.properties` and set `template.company` (consumed by the root `build.gradle.kts` Spotless config). Then run `./gradlew spotlessApply` to rewrite every header.
+2. **License file:** open `LICENSE.md` and replace `[year]` and the placeholder name with your own.
+3. **README and docs:** update the badges (CI, stars, forks) to point at your repo, and replace the project description in this file. The script intentionally skips `*.md` so it doesn't break upstream-template links.
+4. **Feature module:** replace the placeholder content in `:feature-example` (start with `ExampleScreen.kt`), and rename the module (`:feature-example` → `:feature-yourname`) once you know what you're building.
+5. **Remove template funding file:** delete `.github/FUNDING.yml`, or replace it with your own sponsorship info.
+
+If you'd rather rename by hand, expand the manual fallback below.
+
+<details>
+<summary>Manual rename fallback</summary>
+
+Use Android Studio's **Refactor > Rename** for the package step.
+
+1. **Project name:** in `settings.gradle.kts`, change `rootProject.name`.
+2. **Application ID & namespaces:** in `app/build.gradle.kts` and every library module's `build.gradle.kts`, change `namespace` (and `applicationId` in `:app`) from `com.thecompany.consultme` to your new ID.
+3. **Package name:** rename the `com.thecompany.consultme` package via Android Studio refactor — that handles source file moves, package declarations, and imports.
+4. **Theme + application class:** rename `ConsultMeTheme`, `Theme.ConsultMe` (in `app/src/main/res/values/themes.xml`), and `ConsultMeApplication` (class + filename + `AndroidManifest.xml` reference) to match your new project name.
+5. **App display name:** in `app/src/main/res/values/strings.xml`, change `app_name`.
+6. **Convention plugin IDs:** rename the four files under `build-logic/convention/src/main/kotlin/consultme.android.*.gradle.kts` and update every `id("consultme.android.*")` reference in module build scripts.
+7. Then continue with the post-script steps above (license header, LICENSE file, README badges, feature module, FUNDING.yml).
+
+</details>
+
+## How to add a new feature module
+
+Convention plugins (`build-logic/`) make a new feature module ~20 lines of Gradle. Create `feature-<name>/build.gradle.kts`:
+
+```kotlin
+plugins {
+    id("consultme.android.library")
+    id("consultme.android.compose")
+    id("consultme.android.hilt")
+}
+
+android {
+    namespace = "com.thecompany.consultme.feature.<name>"
+}
+
+dependencies {
+    implementation(projects.coreUi)
+    testImplementation(projects.coreTesting)
+    androidTestImplementation(projects.coreTesting)
+}
+```
+
+Add `include(":feature-<name>")` to `settings.gradle.kts` and depend on it from `:app` via `implementation(projects.feature<NameInPascalCase>)`. The conventions handle `compileSdk`/`minSdk`, JVM toolchain, Compose BOM, Hilt + KSP, and the Hilt test runner.
+
+## How to write a Hilt-aware test
+
+Every module declares `:core-testing` for both unit and instrumented tests, so JUnit/Turbine/MockK/Hilt-testing/Espresso are already on the classpath:
+
+```kotlin
+testImplementation(projects.coreTesting)
+androidTestImplementation(projects.coreTesting)
+```
+
+For an instrumented test that needs Hilt injection, annotate with `@HiltAndroidTest` and use the runner that the convention plugins already wire in (`com.thecompany.consultme.core.testing.HiltTestRunner`):
+
+```kotlin
+@HiltAndroidTest
+class MyFeatureTest {
+    @get:Rule val hilt = HiltAndroidRule(this)
+
+    @Before fun setUp() { hilt.inject() }
+
+    @Test fun feature_does_something() { /* ... */ }
+}
+```
+
+No need to redeclare JUnit/Hilt-testing dependencies in the module's `build.gradle.kts` — `:core-testing` re-exports them with `api(...)`.
+
+## How to regenerate lint baselines
+
+Each module ships its own `lint-baseline.xml`. Regenerate after adding code that introduces new lint warnings (rather than hand-editing):
+
+```bash
+./gradlew :feature-example:updateLintBaseline
+```
+
+Replace `:feature-example` with the module you're updating. CI runs `lintRelease` and fails on any non-baselined violation.
 
 ## Code Quality
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,12 @@ plugins {
     alias(libs.plugins.detekt) apply false
 }
 
+// Adopters override these in gradle.properties (template.company / template.licenseYear).
+// $YEAR is a Spotless token resolved at apply time; keep it as the default.
+val templateCompany = (findProperty("template.company") as? String)?.takeIf { it.isNotBlank() } ?: "MyCompany"
+val templateLicenseYear = (findProperty("template.licenseYear") as? String)?.takeIf { it.isNotBlank() } ?: "\$YEAR"
+val licenseHeaderText = "// Copyright $templateLicenseYear $templateCompany"
+
 subprojects {
     plugins.apply(rootProject.libs.plugins.spotless.get().pluginId)
     plugins.apply(rootProject.libs.plugins.detekt.get().pluginId)
@@ -20,23 +26,13 @@ subprojects {
         kotlin {
             target("**/*.kt")
             // Header is placed AFTER the `package` declaration via the delimiter.
-            licenseHeader(
-                """
-                // Copyright ${'$'}YEAR MyCompany
-                """.trimIndent(),
-                "package ",
-            )
+            licenseHeader(licenseHeaderText, "package ")
             ktlint(libs.ktlint.get().version)
         }
         kotlinGradle {
             target("*.gradle.kts")
             // No `package` line in Gradle scripts; place header above the first `/*`.
-            licenseHeader(
-                """
-                // Copyright ${'$'}YEAR MyCompany
-                """.trimIndent(),
-                "/*",
-            )
+            licenseHeader(licenseHeaderText, "/*")
             ktlint(libs.ktlint.get().version)
         }
     }

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -7,8 +7,8 @@ ConsultMe is a Jetpack Compose multi-module Android template. This document is t
 | Phase | Theme | State |
 |---|---|---|
 | 0 | Cleanup & flexibility | **Done** (#97) |
-| 1 | Convention plugins (`build-logic/`) | **Done** (this PR) |
-| 2 | Template ergonomics (bootstrap script, parameterized header) | Not started |
+| 1 | Convention plugins (`build-logic/`) | **Done** (#101) |
+| 2 | Template ergonomics (bootstrap script, parameterized header) | **In progress** (this PR) |
 | 3 | Real example tests | Not started |
 | 4 | Production-readiness (R8, CI artifacts, instrumented tests) | Not started |
 | 5 | Deferred migrations (AGP 9, Hilt 2.59+, Kotlin 2.3.20) | Blocked by upstream pin in `dependabot.yml` |
@@ -65,13 +65,15 @@ Two ergonomic wins layered onto the convention plugins, both from [Modexa, "7 Gr
 - **Type-safe project accessors** — `enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")` in `settings.gradle.kts`; modules now use `projects.coreUi` etc. instead of `project(":core-ui")`. Required renaming `rootProject.name` from `"Consult Me"` to `"ConsultMe"` (build identifier; user-facing app name in `strings.xml` is unchanged).
 - **Bundles for Compose + testing dependencies** — `[bundles]` entries in `gradle/libs.versions.toml`: `androidx-compose`, `androidx-compose-debug`, `test-shared`. The compose convention plugin's dep list shrunk from 10 lines to 6; `:core-testing`'s 11 `api()` lines collapsed to one `api(libs.bundles.test.shared)`. The Compose BOM stays unbundled because `platform(...)` can't wrap a bundle.
 
-## Phase 2 — Template ergonomics
+## Phase 2 — Template ergonomics (in progress)
 
 Goal: turn the manual "find/replace these 8 places" rename ritual into one command and parameterize the company name.
 
-- **`scripts/rename-template.sh com.acme.myapp "My App Name"`** that does the package rename, namespace updates, `applicationId` change, manifest activity references, `app_name`, and `rootProject.name` in one pass. Cross-shell-safe (use POSIX `sh` or python).
-- **Parameterize the Spotless license header** via `gradle.properties` (`template.company=MyCompany`, `template.licenseYear=$YEAR`). Read in the root `build.gradle.kts` Spotless config.
-- **Rewrite README's "How to Rename" section** to point at the script as the primary path, keep the manual fallback as an appendix. Add new sections: "How to add a new feature module" (after Phase 1, this is one line), "How to write a Hilt-aware test" (snippet using `:core-testing`'s `HiltTestRunner`), "How to regenerate lint baselines" (`./gradlew :module:updateLintBaseline`).
+Shipped in this PR:
+
+- **`scripts/rename-template.py com.acme.myapp "My App Name"`** — single-pass rewrite of package (namespace, applicationId, source dirs, package/import statements), project identifier (rootProject.name, `Theme.<name>`, `<name>Theme` composable, `<name>Application` class + filename), convention plugin slug (`consultme.android.*` → `<lower>.android.*`), and app display name. Implemented in Python 3 for cross-platform `sed -i` safety; the file is `.py` rather than `.sh` because the spec explicitly endorsed either. Re-running with the same args is a no-op.
+- **Parameterized Spotless license header** via two `gradle.properties` keys (`template.company`, `template.licenseYear`). Defaults preserve existing `// Copyright $YEAR MyCompany` output; adopters override `template.company` once per fork.
+- **README rewrite** — the rename section now points at the script first; manual steps are an appendix (`#manual-rename-fallback`). Added "How to add a new feature module," "How to write a Hilt-aware test," and "How to regenerate lint baselines" sections.
 
 ## Phase 3 — Real example tests
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,9 @@ org.gradle.configuration-cache=true
 
 # Speed up the build
 org.gradle.caching=true
+
+# Spotless license header (consumed by the root build.gradle.kts).
+# Adopters: change template.company once after forking; leave template.licenseYear
+# as $YEAR so spotlessApply rewrites the current year on demand.
+template.company=MyCompany
+template.licenseYear=$YEAR

--- a/scripts/rename-template.py
+++ b/scripts/rename-template.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright 2026 MyCompany
+"""Rename the ConsultMe template to a new package and app name.
+
+Usage:
+    scripts/rename-template.py com.acme.myapp "My App Name"
+
+Performs in one pass:
+- Package rename (com.thecompany.consultme -> <new-package>): namespace,
+  applicationId, source directory paths, package/import statements, the
+  build-logic plugin group, and the testInstrumentationRunner reference.
+- Project identifier rename (ConsultMe -> PascalCase of the app name):
+  rootProject.name, Theme.<name>, <name>Theme composable, <name>Application
+  class and its filename. Manifest activity references update automatically
+  because they're already namespace-relative (".MainActivity",
+  ".ConsultMeApplication").
+- Convention plugin slug rename (consultme.android.* -> <lowercase>.android.*):
+  the four precompiled-script-plugin filenames under build-logic/ and every
+  `id("consultme.android.*")` reference in module build scripts.
+- App display name rename (Consult Me -> <new app name>): app_name string.
+
+Scope: rewrites .kt, .kts, .xml, .toml, .properties files only. README,
+CLAUDE.md, LICENSE.md, and docs/ are intentionally skipped — they contain
+upstream-template references (badge URLs, etc.) that adopters update by hand.
+
+Run from the repo root. Re-running with the same args is a no-op.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+OLD_PACKAGE = "com.thecompany.consultme"
+OLD_PROJECT = "ConsultMe"
+OLD_APP_NAME = "Consult Me"
+OLD_PLUGIN_SLUG = "consultme"  # leading segment of the convention plugin IDs
+
+TEXT_SUFFIXES = {".kt", ".kts", ".xml", ".toml", ".properties"}
+SKIP_DIRS = {".git", "build", ".gradle", ".idea", "node_modules"}
+
+
+def fail(msg: str) -> None:
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def to_pascal(name: str) -> str:
+    parts = re.findall(r"[A-Za-z0-9]+", name)
+    if not parts:
+        fail(f"app name '{name}' has no alphanumeric characters")
+    return "".join(p[:1].upper() + p[1:] for p in parts)
+
+
+def validate_package(pkg: str) -> None:
+    if not re.fullmatch(r"[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+", pkg):
+        fail(f"invalid package '{pkg}'; expected lowercase, dot-separated, e.g. com.acme.myapp")
+
+
+def iter_files(root: Path):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fname in filenames:
+            yield Path(dirpath, fname)
+
+
+def rewrite_text(path: Path, replacements: list[tuple[str, str]]) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return False
+    new_text = text
+    for old, new in replacements:
+        new_text = new_text.replace(old, new)
+    if new_text == text:
+        return False
+    path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def move_package_dirs(root: Path, old_path: str, new_path: str) -> None:
+    if old_path == new_path:
+        return
+    sep = os.sep
+    old_suffix = sep + old_path.replace("/", sep)
+    matches = []
+    for dirpath, _, _ in os.walk(root):
+        if any(part in SKIP_DIRS for part in Path(dirpath).parts):
+            continue
+        if dirpath.endswith(old_suffix):
+            matches.append(Path(dirpath))
+    for src in matches:
+        anchor = Path(str(src)[: -len(old_suffix)])
+        dst = anchor / new_path.replace("/", sep)
+        if dst.exists():
+            for child in src.iterdir():
+                target = dst / child.name
+                if not target.exists():
+                    shutil.move(str(child), str(target))
+            if not any(src.iterdir()):
+                src.rmdir()
+        else:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+        # Prune empty parent dirs left behind (e.g. com/thecompany after consultme moves).
+        parent = src.parent
+        while parent != anchor and parent.exists() and not any(parent.iterdir()):
+            parent.rmdir()
+            parent = parent.parent
+
+
+def rename_project_files(root: Path, old: str, new: str) -> None:
+    if old == new:
+        return
+    for path in iter_files(root):
+        if path.suffix == ".kt" and old in path.name:
+            path.rename(path.with_name(path.name.replace(old, new)))
+
+
+def rename_plugin_files(root: Path, old_slug: str, new_slug: str) -> None:
+    if old_slug == new_slug:
+        return
+    prefix = f"{old_slug}.android."
+    for path in iter_files(root):
+        if path.name.startswith(prefix) and path.name.endswith(".gradle.kts"):
+            path.rename(path.with_name(path.name.replace(old_slug, new_slug, 1)))
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    new_package = sys.argv[1].strip()
+    new_app_name = " ".join(sys.argv[2].split())
+    if not new_app_name:
+        fail("app name cannot be empty")
+    validate_package(new_package)
+
+    root = Path.cwd().resolve()
+    if not (root / "settings.gradle.kts").exists():
+        fail(f"settings.gradle.kts not found in {root}; run from the repo root")
+
+    new_project = to_pascal(new_app_name)
+    new_plugin_slug = new_project.lower()
+    old_pkg_path = OLD_PACKAGE.replace(".", "/")
+    new_pkg_path = new_package.replace(".", "/")
+
+    print(f"Package:      {OLD_PACKAGE} -> {new_package}")
+    print(f"Project name: {OLD_PROJECT} -> {new_project}")
+    print(f"Plugin slug:  {OLD_PLUGIN_SLUG}.android.* -> {new_plugin_slug}.android.*")
+    print(f"App name:     '{OLD_APP_NAME}' -> '{new_app_name}'")
+
+    # Order matters: the package replacement runs first so that the lowercase
+    # 'consultme' slug replacement that follows only touches plugin IDs, not
+    # the package suffix.
+    replacements = [
+        (OLD_PACKAGE, new_package),
+        (OLD_PROJECT, new_project),
+        (f"{OLD_PLUGIN_SLUG}.android.", f"{new_plugin_slug}.android."),
+        (OLD_APP_NAME, new_app_name),
+    ]
+    changed = 0
+    for path in iter_files(root):
+        if path.suffix not in TEXT_SUFFIXES:
+            continue
+        if rewrite_text(path, replacements):
+            changed += 1
+
+    move_package_dirs(root, old_pkg_path, new_pkg_path)
+    rename_project_files(root, OLD_PROJECT, new_project)
+    rename_plugin_files(root, OLD_PLUGIN_SLUG, new_plugin_slug)
+
+    print(f"\nRewrote {changed} file(s); moved package directories; renamed project files.")
+    print("Next steps:")
+    print("  - Update README badges and docs/ references by hand.")
+    print("  - ./gradlew spotlessApply   # rewrite license header (set template.company first)")
+    print("  - ./gradlew test            # confirm everything compiles")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **`scripts/rename-template.py`** — single-pass rewrite of package, namespace, `applicationId`, source dirs, project identifier (rootProject.name + theme + Application class), convention plugin slug (`consultme.android.*` → `<lower>.android.*`), and `app_name`. Validated end-to-end by running on a copy of the repo and `compileDebugKotlin`-ing it. Re-running with the same args is a no-op.
- **Parameterized Spotless license header** via `gradle.properties` (`template.company`, `template.licenseYear`). Defaults preserve `// Copyright \$YEAR MyCompany`; verified an override with `-Ptemplate.company=Acme` produces the expected diff.
- **README rewrite** — rename section now leads with the script; manual fallback collapsed inline (`<details>`). Added sections for adding a feature module, Hilt-aware tests, and regenerating lint baselines.
- **`docs/IMPROVEMENT_PLAN.md`** — Phase 2 status updated; scope reflects the actual `.py` filename (the spec endorsed either POSIX sh or python).

Implementation note: the script handles a fourth axis the original spec didn't enumerate — the convention plugin slug (`consultme.android.*`). Without that, post-rename modules would still apply plugins under the old project's name.

## Test plan

- [x] `./gradlew spotlessCheck detekt lintRelease test` — all pass on this branch
- [x] Spotless property override — `-Ptemplate.company=Acme` produces a different header (verified by `--rerun-tasks` failure with the expected diff)
- [x] Rename script end-to-end — copied repo to /tmp, ran `rename-template.py com.acme.myapp "My App Name"`, verified directories moved, no `consultme`/`ConsultMe` refs remained, and `./gradlew compileDebugKotlin` succeeded
- [x] Rename script idempotency — second run with same args is a no-op
- [x] Argument validation — invalid package, empty app name, and running outside repo root each fail cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)