### PR TITLE
chore: sync .idea/gradle.xml with build-logic included build

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,12 +4,26 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT">
+            <builds>
+              <build path="$PROJECT_DIR$/build-logic" name="build-logic">
+                <projects>
+                  <project path="$PROJECT_DIR$/build-logic" />
+                  <project path="$PROJECT_DIR$/build-logic/convention" />
+                </projects>
+              </build>
+            </builds>
+          </compositeBuild>
+        </compositeConfiguration>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
+            <option value="$PROJECT_DIR$/build-logic" />
+            <option value="$PROJECT_DIR$/build-logic/convention" />
             <option value="$PROJECT_DIR$/core-data" />
             <option value="$PROJECT_DIR$/core-database" />
             <option value="$PROJECT_DIR$/core-testing" />


### PR DESCRIPTION
IntelliJ updated its module list and composite-build descriptor after Phase 1 (#101) wired `build-logic/` as an included build. Same incidental IDE sync that #100 cleaned up after the `:feature-example` rename.

No runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)