### PR TITLE
ci: Phase 4 (1/3) — assembleRelease, artifact upload, GMD job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,6 +73,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "Tarek-Bohdima"
+    assignees:
+      - "Tarek-Bohdima"
     commit-message:
       prefix: "chore"
       include: "scope"
+    # Bundle all action SHA bumps into a single weekly PR so the workflow gets
+    # reviewed atomically rather than five PRs each touching one line.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -92,6 +92,11 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: Accept Android SDK licenses
+        # The runner has the emulator license accepted but not aosp_atd system
+        # images. Pre-accept everything so AGP can install the missing package.
+        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null
+
       - name: Cache AVD system image
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -7,6 +7,11 @@ permissions:
 on:
   pull_request: # Triggers on any pull request
 
+# Cancel in-progress runs when a new commit lands on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
@@ -41,3 +46,65 @@ jobs:
 
       - name: Run unit tests
         run: ./gradlew test
+
+      - name: Assemble release APK
+        # Catches release-only build regressions (resource shrinking, R8 keep
+        # rules, etc.) that the unit-test path can't surface.
+        run: ./gradlew assembleRelease
+
+      - name: Upload lint + unit test reports
+        # Always upload reports — they're most useful when the build above fails.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-reports
+          path: |
+            **/build/reports/lint-results-*.html
+            **/build/reports/tests/**
+          if-no-files-found: ignore
+
+  instrumented_tests:
+    # Runs the Gradle Managed Device (pixel6api30, aosp-atd) registered by the
+    # convention plugins. Not yet wired into branch protection — opt in via the
+    # repo's required-checks settings once GMD has run a few times reliably.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Enable KVM for emulator acceleration
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Cache AVD system image
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-pixel6api30-${{ hashFiles('build-logic/**/*.kt', 'build-logic/**/*.gradle.kts') }}
+
+      - name: Run instrumented tests on pixel6api30
+        run: ./gradlew pixel6api30DebugAndroidTest
+
+      - name: Upload instrumented test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-test-reports
+          path: '**/build/reports/androidTests/**'
+          if-no-files-found: ignore

--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -1,6 +1,6 @@
 name: Android CI
 
-# This permission is a good security practice, limiting the workflow's access to read-only.
+# Read-only token; no fork PR can write back to the repo via this workflow.
 permissions:
   contents: read
 
@@ -12,25 +12,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Third-party actions are pinned to commit SHAs (with the version tag in a
+# trailing comment) to neutralize supply-chain risk: a compromised upstream
+# action can't silently swap behavior under us. Dependabot's `github-actions`
+# ecosystem auto-bumps these on a weekly cadence.
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        # Using a major version tag (@v4) is convenient and receives security updates.
-        # For maximum security, you can pin this to a specific commit hash instead.
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        # This action automatically handles Gradle caching and dependency submission.
-        # As of v4, it also includes Gradle Wrapper validation.
-        uses: gradle/actions/setup-gradle@v6
+        # Auto-handles Gradle caching, dependency submission, and Wrapper validation.
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
@@ -55,13 +56,14 @@ jobs:
       - name: Upload lint + unit test reports
         # Always upload reports — they're most useful when the build above fails.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build-reports
           path: |
             **/build/reports/lint-results-*.html
             **/build/reports/tests/**
           if-no-files-found: ignore
+          retention-days: 7
 
   instrumented_tests:
     # Runs the Gradle Managed Device (pixel6api30, aosp-atd) registered by the
@@ -70,16 +72,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
@@ -91,7 +93,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Cache AVD system image
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.android/avd/*
@@ -103,8 +105,9 @@ jobs:
 
       - name: Upload instrumented test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: instrumented-test-reports
           path: '**/build/reports/androidTests/**'
           if-no-files-found: ignore
+          retention-days: 7

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -9,8 +9,8 @@ ConsultMe is a Jetpack Compose multi-module Android template. This document is t
 | 0 | Cleanup & flexibility | **Done** (#97) |
 | 1 | Convention plugins (`build-logic/`) | **Done** (#101) |
 | 2 | Template ergonomics (bootstrap script, parameterized header) | **Done** (#104) |
-| 3 | Real example tests | **In progress** (this PR) |
-| 4 | Production-readiness (R8, CI artifacts, instrumented tests) | Not started |
+| 3 | Real example tests | **Done** (#105) |
+| 4 | Production-readiness (R8, CI artifacts, instrumented tests) | **In progress** — CI sub-piece in this PR; R8 + docs follow-ups still open |
 | 5 | Deferred migrations (AGP 9, Hilt 2.59+, Kotlin 2.3.20) | Blocked by upstream pin in `dependabot.yml` |
 
 Tick the table when phases land. Each phase below lists scope, rationale, and a rough size; sub-bullets are the concrete deltas.
@@ -86,15 +86,18 @@ Goal: replace the empty `ExampleUnitTest` shells with code that doubles as docum
   - A Compose UI test asserting the screen renders.
 - Each test stays small (≤ 30 lines) — the goal is exemplification, not coverage.
 
-## Phase 4 — Production-readiness
+## Phase 4 — Production-readiness (in progress)
 
-Goal: a fork from this template should be one signing config away from a Play release.
+Goal: a fork from this template should be one signing config away from a Play release. Splitting this phase across multiple PRs so each piece can be tuned independently.
 
+**CI sub-piece (this PR):**
+- `assembleRelease` step in `build_and_test` (catches APK build regressions `test` misses).
+- Upload `*/build/reports/lint-results-*.html` and `*/build/reports/tests/**` after every run (`if: always()` so they survive failures).
+- New parallel `instrumented_tests` job runs the GMD profile registered in #105 (`./gradlew pixel6api30DebugAndroidTest`). Includes KVM enable, AVD cache, and instrumented-test report upload. Not yet wired into branch protection — opt in via the repo's required-checks settings once the job has run a few times reliably.
+- Workflow now uses a `concurrency` group so superseded commits cancel mid-flight.
+
+**Still open (follow-up PRs):**
 - Flip `isMinifyEnabled = true` for release in `:app`. Add starter `proguard-rules.pro` with the Hilt + Compose + Room rules every project needs (most are already in the AGP defaults; document the few that aren't). The official [`r8-analyzer`](https://github.com/android/skills) Claude Code skill helps surface missing keep rules from a release build.
-- CI additions in `.github/workflows/android_ci.yml`:
-  - `./gradlew assembleRelease` (catches APK build regressions that `test` misses).
-  - Upload `*/build/reports/lint-results-*.html` and `*/build/reports/tests/**` as artifacts.
-  - Add a Gradle Managed Devices step for `connectedCheck` (cheaper and more reliable than self-hosted emulators). The device profile (`pixel6api30`, `aosp-atd`) is already registered by the library + application convention plugins as of #105 — Phase 4's job is to enable the corresponding workflow step (`./gradlew pixel6api30DebugAndroidTest`) and make sure KVM is available on the runner.
 - Add `CONTRIBUTING.md`, `PULL_REQUEST_TEMPLATE.md`, and a polished `CODE_OF_CONDUCT.md` (Contributor Covenant).
 
 ## Phase 5 — Deferred migrations


### PR DESCRIPTION
First slice of Phase 4. Splitting the phase into three PRs so each piece can be tuned independently:
1. **CI workflow + security tightening (this PR)**
2. R8 + `proguard-rules.pro`
3. `CONTRIBUTING.md` + PR template + Code of Conduct

Tag-strategy docs ship in their own PR (separate concern from CI).

## Summary

**CI additions:**
- `assembleRelease` step in `build_and_test`. Catches release-only build regressions (resource shrinking, R8 keep rules once enabled, etc.).
- Artifact upload with `if: always()` so lint + unit-test reports come through on red builds (`build-reports`).
- New parallel `instrumented_tests` job runs the `pixel6api30` GMD profile registered in #105. KVM enable, AVD cache keyed on convention-plugin sources, and instrumented-test report upload (`instrumented-test-reports`). Not yet wired into branch protection — flip the required-checks setting once it has run a few times reliably.
- Concurrency group so superseded commits cancel mid-flight.

**Security tightening (added after review):**
- All third-party actions pinned to commit SHAs (with version tag in trailing comment). Mitigates a compromised upstream action silently swapping behavior.
- `retention-days: 7` on both artifact uploads — reports expire in a week instead of 90 days.
- Dependabot's `github-actions` ecosystem brought to parity with `gradle` (reviewers, assignees, PR limit, grouping) so weekly SHA bumps land atomically.

The first run of `instrumented_tests` will be slow (1-2 GB system image download); subsequent runs hit the cache.

## Test plan

- [x] `./gradlew assembleRelease` — local 2m25s, passes
- [x] `./gradlew spotlessCheck detekt lintRelease test` — all gates pass
- [ ] First CI run will exercise the new steps end-to-end
- [ ] If GMD is too flaky, easy to gate behind a label or schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)