### PR TITLE
docs: tag/release strategy + governance notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,5 +73,24 @@ Skills are not vendored — install locally when starting the matching phase. Se
 `main` is protected:
 - Direct pushes rejected — every change goes through a PR.
 - `build_and_test` (the workflow in `.github/workflows/android_ci.yml`) is a required check.
+- `instrumented_tests` (Gradle Managed Device job) is **not yet required** — let it bake for a few PRs, then promote it via Repo → Settings → Branches → main.
 - GitHub auto-merge is **disabled** at the repo level. Merging requires `gh pr merge --admin --squash --delete-branch` (admin override) or clicking merge in the UI.
-- Dependabot opens grouped PRs weekly; they get squash-merged like any other PR.
+- Dependabot opens grouped PRs weekly (Gradle deps + workflow action SHAs); they get squash-merged like any other PR.
+- **Fork PR approval**: Repo → Settings → Actions → General → "Require approval for first-time contributors" should stay enabled. Without it, anyone forking can spam workflow runs through unlimited public-repo Action minutes. (No $ cost on a public repo, but GitHub may rate-limit the org under abuse.)
+- Third-party actions in workflows are **pinned to commit SHAs** (with the version tag in a trailing comment). Dependabot's `github-actions` ecosystem auto-bumps them weekly. When reviewing those PRs, glance at the upstream changelog before merging — that's the value SHA-pinning gives you.
+
+## Versioning and tags
+
+Tags follow SemVer with a template-adopter lens: a "breaking change" is one that affects a downstream fork, not just an internal refactor.
+
+| Bump | When |
+|------|------|
+| **MAJOR** (`vX.0.0`) | Breaking changes for adopters — `minSdk` bump, AGP/Kotlin/Hilt major migration, convention-plugin API renames, removing or renaming a module |
+| **MINOR** (`v1.X.0`) | A phase landing, new convention plugin, new feature module template, additive opt-in tooling |
+| **PATCH** (`v1.0.X`) | Bug fixes, doc-only changes, dep bumps from Dependabot |
+
+**Conventions:**
+- **Tag at phase boundaries** from `docs/IMPROVEMENT_PLAN.md`, not arbitrarily. So Phase 0+1+1polish+2+3 collapse into a single tag; Phase 4 into the next; etc.
+- **Every tag is a GitHub Release** with auto-generated notes, not just a bare git tag. Use `gh release create vX.Y.Z --generate-notes`.
+- **Pre-release suffixes** (`v2.0.0-rc.1`) for the Phase 5 deferred migrations (AGP 9 / Hilt 2.59 / Kotlin 2.3.20+) so adopters can preview before promotion.
+- Old `v1.0.0`–`v1.4.0` tags from August 2025 are pre-roadmap and immutable; they don't map to any current phase. The next tag after Phase 4 wraps will be **`v2.0.0`** (the `minSdk` 25→26 in #105 is breaking for any fork from `v1.4.0`).

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Replace `:feature-example` with the module you're updating. CI runs `lintRelease
 - **Detekt**: Finds common code issues.
 - **Lint**: Enforces Kotlin and Compose best practices.
 
+## Versioning
+
+Tags follow SemVer with a template-adopter lens: **MAJOR** = breaking change for downstream forks (`minSdk` bump, AGP/Kotlin major migration, convention-plugin API rename), **MINOR** = a phase landing or new opt-in tooling, **PATCH** = bug fixes and dep bumps. Tags align with phase boundaries in [`docs/IMPROVEMENT_PLAN.md`](docs/IMPROVEMENT_PLAN.md), and every tag ships as a GitHub Release. See [`CLAUDE.md`](CLAUDE.md#versioning-and-tags) for the full policy.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -135,3 +135,7 @@ Skills are not vendored into the template — they're maintained upstream by Goo
 ## How to use this document
 
 When starting a phase, change its row in the status table to **In progress**, link the PR, and update sub-bullets with checkboxes if it helps. When merged, mark **Done** with the PR number. The point is to keep the next-best action obvious to whoever opens the repo a month from now.
+
+## Releases
+
+Cut a GitHub Release at every phase boundary, not arbitrarily. Phase 0–3 collapse into one MAJOR (`v2.0.0`, because Phase 3's `minSdk` 25→26 is breaking for adopters); Phase 4 ships as `v2.1.0` (or another MAJOR if R8 introduces required keep-rule changes for forks); Phase 5 ships as `v3.0.0` since AGP 9 / Hilt 2.59 / Kotlin 2.3.20+ each force adopter migrations. See `CLAUDE.md` "Versioning and tags" for the full policy.


### PR DESCRIPTION
Documents the tag/release strategy you asked for plus a few governance notes from the security review. No code changes.

## Summary

**`CLAUDE.md` — new \"Versioning and tags\" section:**
SemVer with a template-adopter lens — *breaking* means breaking for a downstream fork, not just internal refactors.

| Bump | When |
|------|------|
| **MAJOR** | `minSdk` bump, AGP/Kotlin/Hilt major migration, convention-plugin API rename, removing/renaming a module |
| **MINOR** | A phase landing, new convention plugin, additive opt-in tooling |
| **PATCH** | Bug fixes, doc-only, dep bumps |

Tags align with phase boundaries in `IMPROVEMENT_PLAN.md`; every tag ships as a GitHub Release with auto-generated notes (`gh release create vX.Y.Z --generate-notes`). Pre-release suffixes (`v2.0.0-rc.1`) for Phase 5 deferred migrations.

**`CLAUDE.md` — CI/branch protection updates:**
- Note that `instrumented_tests` (GMD job from #107) is intentionally not yet a required check; promote it after a few clean runs.
- Add the \"Require approval for first-time contributors\" repo setting as a documented governance bullet.
- Note that workflow actions are SHA-pinned with weekly Dependabot bumps.

**`README.md`:** brief \"Versioning\" section pointing at the full policy.

**`docs/IMPROVEMENT_PLAN.md`:** \"Releases\" subsection mapping phase boundaries to tags. Calls out that the next tag is **`v2.0.0`** (Phase 0–3 + the `minSdk` 25→26 bump in #105 = breaking change for adopters of `v1.4.0`).

Old `v1.0.0`–`v1.4.0` tags from August 2025 are immutable pre-roadmap history; they stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)