### PR TITLE
chore: tighten Dependabot ignores to cover library coordinates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,12 +16,27 @@ updates:
     ignore:
       # AGP 9.x removes the kotlin-android plugin requirement and bumps Gradle
       # to 9.4+. Defer until that migration is done in a dedicated change.
+      # Each pin must cover BOTH the plugin id (referenced from [plugins]) AND
+      # the Maven coordinate (referenced from [libraries], used by build-logic
+      # for compileOnly classpath wiring) — Dependabot treats them separately.
       - dependency-name: "com.android.application"
         update-types: ["version-update:semver-major"]
       - dependency-name: "com.android.library"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "com.android.test"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "com.android.tools.build:gradle"
+        update-types: ["version-update:semver-major"]
       # Hilt 2.59+ requires AGP 9. Hold at 2.58.x until the AGP 9 migration.
       - dependency-name: "com.google.dagger.hilt.android"
+        versions: [">=2.59"]
+      - dependency-name: "com.google.dagger:hilt-android"
+        versions: [">=2.59"]
+      - dependency-name: "com.google.dagger:hilt-compiler"
+        versions: [">=2.59"]
+      - dependency-name: "com.google.dagger:hilt-android-testing"
+        versions: [">=2.59"]
+      - dependency-name: "com.google.dagger:hilt-android-gradle-plugin"
         versions: [">=2.59"]
       # Kotlin 2.3.20+ promotes -Xcontext-receivers from warning to a hard
       # error in release variants, breaking compileReleaseKotlin in
@@ -30,6 +45,10 @@ updates:
       - dependency-name: "org.jetbrains.kotlin.android"
         versions: [">=2.3.20"]
       - dependency-name: "org.jetbrains.kotlin.plugin.compose"
+        versions: [">=2.3.20"]
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
+        versions: [">=2.3.20"]
+      - dependency-name: "org.jetbrains.kotlin:compose-compiler-gradle-plugin"
         versions: [">=2.3.20"]
 
     # Group related dependency updates into single pull requests


### PR DESCRIPTION
## Summary
- The Phase 5 pins in \`.github/dependabot.yml\` only targeted plugin ids (\`com.android.application\`, \`org.jetbrains.kotlin.android\`, etc.), but \`build-logic\` also references AGP / Kotlin / Hilt via their Maven coordinates (\`com.android.tools.build:gradle\`, \`org.jetbrains.kotlin:kotlin-gradle-plugin\`, …) as \`compileOnly\` classpath deps. Dependabot treats those as separate dependencies, so the AGP 9 (#111) and Kotlin 2.3.21 (#110) PRs slipped past the rules and immediately failed CI.
- Add matching library-coordinate ignore entries for AGP, Kotlin, and Hilt, and add the previously uncovered \`com.android.test\` plugin id, so each pin holds across both \`[plugins]\` and \`[libraries]\` references.
- No code or build changes — pure Dependabot config.

After this lands, #110 and #111 can be closed; future bumps will be blocked at the Dependabot run rather than reaching CI.

## Test plan
- [ ] CI \`build_and_test\` and \`instrumented_tests\` are green (config-only change, but workflows run on every PR).
- [ ] Verify the Dependabot config is valid via the repo's "Dependabot" tab → "Last update job" once merged.
- [ ] Confirm a future \`@dependabot recreate\` on a hypothetical 2.3.22 / 9.x PR is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)