### PR TITLE
feat: Phase 4 (2/3) — R8 + resource shrinking for release

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,26 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+# Project-specific R8 / ProGuard keep rules for :app.
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# This file complements the platform defaults in proguard-android-optimize.txt
+# and the AAR-shipped consumer rules from each dependency (Hilt, Room, Compose,
+# kotlinx.coroutines, …). The template's current dependencies don't require any
+# custom keep rules — leave this slim and add to it only when the situations
+# below apply to the fork.
+#
+# Add a rule here when:
+#   - You expose data/model classes to a reflective serializer
+#     (Gson, kotlinx.serialization, Moshi reflective, Jackson, …).
+#   - You load classes by name (Class.forName, ServiceLoader, …).
+#   - A release build trips a NoClassDefFoundError, MissingResourceException,
+#     or "Class not found" warning that the platform defaults don't cover.
+#
+# Tip: The official `r8-analyzer` Claude Code skill
+# (https://github.com/android/skills) consumes the build/outputs/mapping/release
+# artifacts (usage.txt, configuration.txt, mapping.txt) and surfaces what R8
+# stripped and why — use it before adding broad -keep rules by hand.
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Preserve filename + line numbers so production crashes (Crashlytics, Play
+# Console, your own logger) symbolicate via the mapping.txt that AGP writes
+# under build/outputs/mapping/release/. Without these, stack traces collapse
+# to obfuscated identifiers with no source positions.
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/build-logic/convention/src/main/kotlin/consultme.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/consultme.android.application.gradle.kts
@@ -18,7 +18,8 @@ extensions.configure<ApplicationExtension> {
     }
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -90,14 +90,18 @@ Goal: replace the empty `ExampleUnitTest` shells with code that doubles as docum
 
 Goal: a fork from this template should be one signing config away from a Play release. Splitting this phase across multiple PRs so each piece can be tuned independently.
 
-**CI sub-piece (this PR):**
+**CI sub-piece (#107):**
 - `assembleRelease` step in `build_and_test` (catches APK build regressions `test` misses).
 - Upload `*/build/reports/lint-results-*.html` and `*/build/reports/tests/**` after every run (`if: always()` so they survive failures).
 - New parallel `instrumented_tests` job runs the GMD profile registered in #105 (`./gradlew pixel6api30DebugAndroidTest`). Includes KVM enable, AVD cache, and instrumented-test report upload. Not yet wired into branch protection — opt in via the repo's required-checks settings once the job has run a few times reliably.
 - Workflow now uses a `concurrency` group so superseded commits cancel mid-flight.
 
-**Still open (follow-up PRs):**
-- Flip `isMinifyEnabled = true` for release in `:app`. Add starter `proguard-rules.pro` with the Hilt + Compose + Room rules every project needs (most are already in the AGP defaults; document the few that aren't). The official [`r8-analyzer`](https://github.com/android/skills) Claude Code skill helps surface missing keep rules from a release build.
+**R8 sub-piece (this PR):**
+- `isMinifyEnabled = true` and `isShrinkResources = true` for the release build type in the `consultme.android.application` convention plugin. Every adopter inherits R8 + resource shrinking on release without having to touch their app module.
+- `:app/proguard-rules.pro` rewritten as a slim starter — the only project-specific rule is `-keepattributes SourceFile,LineNumberTable` (with the matching `-renamesourcefileattribute SourceFile`) so production crashes symbolicate via the `mapping.txt` AGP writes under `build/outputs/mapping/release/`. The platform defaults (`proguard-android-optimize.txt`) plus AAR-shipped consumer rules from Hilt, Compose, Room, and kotlinx.coroutines cover the rest. Comments document when adopters need to add their own keeps (reflective serializers, `Class.forName`, etc.) and point at the [`r8-analyzer`](https://github.com/android/skills) Claude Code skill.
+- Validated locally: `:app:assembleRelease` ships a 896 KB unsigned release APK; `:app:lintRelease` and `./gradlew test` are clean.
+
+**Still open (follow-up PR):**
 - Add `CONTRIBUTING.md`, `PULL_REQUEST_TEMPLATE.md`, and a polished `CODE_OF_CONDUCT.md` (Contributor Covenant).
 
 ## Phase 5 — Deferred migrations


### PR DESCRIPTION
## Summary
- Flips \`isMinifyEnabled = true\` and \`isShrinkResources = true\` for the release build type in the \`consultme.android.application\` convention plugin, so every adopter inherits R8 + resource shrinking without touching their app module.
- Rewrites \`:app/proguard-rules.pro\` as a slim, well-commented starter. The only project-specific rule is \`-keepattributes SourceFile,LineNumberTable\` (with the matching \`-renamesourcefileattribute\`) so production crashes symbolicate via the \`mapping.txt\` that AGP writes under \`build/outputs/mapping/release/\`. The platform defaults (\`proguard-android-optimize.txt\`) plus AAR-shipped consumer rules from Hilt / Compose / Room / kotlinx.coroutines cover the rest. Comments document when adopters need to add their own keeps (reflective serializers, \`Class.forName\`, …) and point at the [\`r8-analyzer\`](https://github.com/android/skills) Claude Code skill.
- Updates \`docs/IMPROVEMENT_PLAN.md\` to mark this sub-piece shipped; the docs sub-piece (CONTRIBUTING / PR template / CoC) remains as Phase 4 (3/3).

This is part 2 of 3 for Phase 4. Part 1 (#107) wired \`assembleRelease\` and the GMD job into CI, so this PR's exercise of R8 will run on every subsequent PR's \`build_and_test\` job for free.

## Test plan
- [x] \`./gradlew :app:assembleRelease\` succeeds locally; produces a 896 KB unsigned release APK with R8 (\`minifyReleaseWithR8\`) and resource shrinking (\`convertShrunkResourcesToBinaryRelease\`) tasks running clean.
- [x] \`./gradlew :app:lintRelease\` clean (only the Phase 5 pinned-version warnings, unrelated).
- [x] \`./gradlew spotlessCheck detekt test\` clean.
- [ ] CI \`build_and_test\` green (validates R8 in the cloud build).
- [ ] CI \`instrumented_tests\` green (validates the GMD test on the debug variant — R8 doesn't run in debug, but worth confirming nothing else regressed).
- [ ] Spot-check the uploaded \`lint-results-release.html\` artifact for any new lint findings introduced by the release variant change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)