### PR TITLE
docs: Phase 4 (3/3) — community docs (CONTRIBUTING, PR template, issue chooser)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Roadmap and planned phases
+    url: https://github.com/Tarek-Bohdima/ConsultMe/blob/main/docs/IMPROVEMENT_PLAN.md
+    about: Before filing a feature request, check the roadmap — your idea may already be tracked under an upcoming phase or intentionally deferred.
+  - name: Reporting a security issue
+    url: https://github.com/Tarek-Bohdima/ConsultMe/blob/main/CONTRIBUTING.md#reporting-bugs-and-security-issues
+    about: Please don't open a public issue for security vulnerabilities — see CONTRIBUTING.md for the disclosure path.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!--
+  What does this PR change, and why? 1-3 bullets is plenty. Lead with the
+  user/adopter-visible effect; cite the roadmap phase if relevant
+  (docs/IMPROVEMENT_PLAN.md).
+-->
+
+-
+
+## Test plan
+
+<!--
+  What did you run locally, and what will CI validate? Check off as you go.
+  The repo's local CI loop is documented in CONTRIBUTING.md.
+-->
+
+- [ ] `./gradlew spotlessCheck detekt` clean
+- [ ] `./gradlew :app:lintRelease` clean (or baseline regenerated)
+- [ ] `./gradlew test` clean
+- [ ] `./gradlew :app:assembleRelease` succeeds (if touching app/build config or release variant)
+- [ ] CI `build_and_test` and `instrumented_tests` green
+
+## Notes for reviewers
+
+<!--
+  Optional. Anything that makes the diff easier to review: ordering hints,
+  links to upstream changelogs (for dep bumps), known follow-ups deliberately
+  left out of scope, screenshots, before/after build output.
+-->
+
+## Refs
+
+<!-- Closes #N, refs #N, related to docs/IMPROVEMENT_PLAN.md "Phase X". -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to ConsultMe
+
+Thanks for taking an interest in this template. ConsultMe is a Jetpack Compose
+Android template — its scope is the build infrastructure and convention plugins,
+not feature code (the `:feature-example` module is intentionally a placeholder
+that adopters replace). PRs that improve the template's ergonomics, tooling,
+or documentation are very welcome; PRs that add product features should usually
+land in a fork instead.
+
+## Before you start
+
+1. Open an issue for non-trivial changes (anything beyond a doc/typo fix or a
+   one-line bump). The roadmap lives in [`docs/IMPROVEMENT_PLAN.md`](docs/IMPROVEMENT_PLAN.md);
+   if your idea fits an existing phase, link it. If it doesn't, the issue is the
+   right place to discuss whether it should.
+2. If you're touching one of the deferred migrations (AGP 9, Hilt 2.59+,
+   Kotlin 2.3.20+), read the "Phase 5" section of `docs/IMPROVEMENT_PLAN.md`
+   first — those bumps are pinned in `.github/dependabot.yml` for reasons that
+   are documented there. Each is its own dedicated PR, not a passive bump.
+
+## Local setup
+
+You'll need:
+
+- **JDK 17** (the Gradle toolchain pulls it via `jvmToolchain(17)`, but having
+  it on `JAVA_HOME` keeps Android Studio happy).
+- **Android Studio** (any version that supports AGP 8.13). The project opens
+  cleanly with no manual configuration.
+- **Android SDK with API 26+** for `minSdk` and API 36 for `compileSdk` /
+  `targetSdk`. AGP will prompt to install missing components on first sync.
+
+## The local CI loop
+
+CI runs these in order. Run the same gates locally before opening a PR:
+
+```bash
+./gradlew spotlessCheck     # formatting + license headers
+./gradlew detekt            # static analysis
+./gradlew lintRelease       # Android Lint, release variant
+./gradlew test              # all unit tests
+./gradlew :app:assembleRelease  # exercises R8 + resource shrinking
+./gradlew connectedAndroidTest  # instrumented tests (needs device/emulator)
+```
+
+If `spotlessCheck` fails, `./gradlew spotlessApply` autofixes it. If
+`lintRelease` flags something inherent to the variant (rare), regenerate the
+baseline for that module with `./gradlew :<module>:updateLintBaseline` rather
+than hand-editing the XML.
+
+## Pull request conventions
+
+- **`main` is protected.** Direct pushes are rejected; every change goes
+  through a PR. `build_and_test` is a required check.
+- **Conventional commit prefixes.** The repo's commit log uses `feat:`,
+  `fix:`, `chore:`, `docs:`, `ci:`, `build:`, `test:`, and `refactor:`. Match
+  the surrounding style — a glance at `git log --oneline -20` shows the cadence.
+- **One scope per PR.** Splitting CI changes from R8 changes from doc changes
+  keeps each diff easy to review and roll back independently. The roadmap
+  documents how a phase decomposes.
+- **PR description.** Use the template (it'll prefill when you open the PR).
+  The "Test plan" section is load-bearing — list what you ran locally and what
+  CI will validate. Reviewers often scan the test plan before the diff.
+- **Keep dep bumps to Dependabot.** It runs weekly and groups updates
+  sensibly. Manual bumps inside a feature PR muddy the diff and bypass the
+  ignore rules in `.github/dependabot.yml`.
+
+## License header
+
+Every `.kt` and `.gradle.kts` file needs the Spotless-injected header:
+
+```
+// Copyright $YEAR MyCompany
+```
+
+`spotlessApply` writes the year and the `template.company` value from
+`gradle.properties` (defaults to `MyCompany` for the upstream template).
+Adopters override `template.company` once per fork; you don't need to change
+it when contributing back upstream.
+
+## Where things live
+
+- `:app` — application module, wires Hilt + Compose root + nav.
+- `:feature-*` — screen-level features (currently just `:feature-example`).
+- `:core-ui`, `:core-data`, `:core-database`, `:core-testing` — shared layers.
+- `build-logic/` — convention plugins (`consultme.android.application` /
+  `library` / `compose` / `hilt`). Module build scripts compose these instead
+  of redeclaring AGP/Kotlin/lint config. Shared helpers live in
+  `build-logic/convention/src/main/kotlin/com/thecompany/consultme/buildlogic/`.
+- `gradle/libs.versions.toml` — single source of truth for versions, libraries,
+  bundles, and plugins.
+- `docs/IMPROVEMENT_PLAN.md` — the roadmap. Check it before non-trivial work.
+- `CLAUDE.md` — orientation for AI coding assistants; also a good human read for
+  the conventions enforced by tooling.
+
+## Reporting bugs and security issues
+
+- **Bugs** — use the [bug report issue template](.github/ISSUE_TEMPLATE/bug_report.md).
+- **Security issues** — please don't open a public issue. Email the maintainer
+  privately (see the GitHub profile linked in `LICENSE.md`) so a fix can ship
+  before disclosure.
+
+Thanks again — every PR that makes the template easier to fork helps the next
+adopter.

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -101,8 +101,13 @@ Goal: a fork from this template should be one signing config away from a Play re
 - `:app/proguard-rules.pro` rewritten as a slim starter — the only project-specific rule is `-keepattributes SourceFile,LineNumberTable` (with the matching `-renamesourcefileattribute SourceFile`) so production crashes symbolicate via the `mapping.txt` AGP writes under `build/outputs/mapping/release/`. The platform defaults (`proguard-android-optimize.txt`) plus AAR-shipped consumer rules from Hilt, Compose, Room, and kotlinx.coroutines cover the rest. Comments document when adopters need to add their own keeps (reflective serializers, `Class.forName`, etc.) and point at the [`r8-analyzer`](https://github.com/android/skills) Claude Code skill.
 - Validated locally: `:app:assembleRelease` ships a 896 KB unsigned release APK; `:app:lintRelease` and `./gradlew test` are clean.
 
+**Community docs sub-piece (this PR):**
+- `CONTRIBUTING.md` at the repo root — scope statement, local setup, the local CI loop, PR conventions (Conventional Commits, branch protection, one-scope-per-PR), license-header note, repo layout, bug/security reporting paths.
+- `.github/PULL_REQUEST_TEMPLATE.md` — Summary / Test plan / Reviewer notes / Refs sections, mirroring the format the recent PR queue has been using.
+- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues and surfaces two contact links (the roadmap, and the security-disclosure path documented in `CONTRIBUTING.md`).
+
 **Still open (follow-up PR):**
-- Add `CONTRIBUTING.md`, `PULL_REQUEST_TEMPLATE.md`, and a polished `CODE_OF_CONDUCT.md` (Contributor Covenant).
+- Add a polished `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1). Deferred from this PR because the canonical text needs a real enforcement contact filled in, and that's a maintainer decision rather than a template default.
 
 ## Phase 5 — Deferred migrations
 


### PR DESCRIPTION
## Summary

- **\`CONTRIBUTING.md\`** at the repo root — captures the template's scope (build infrastructure / convention plugins, not feature code), local setup (JDK 17, Android Studio, SDK), the local CI loop, PR conventions (Conventional Commits, protected \`main\`, one-scope-per-PR), the Spotless license-header note, and a repo-layout cheat sheet.
- **\`.github/PULL_REQUEST_TEMPLATE.md\`** — Summary / Test plan / Reviewer notes / Refs structure that mirrors the format the recent PR queue (#107, #108, #112, #113) has been using by hand.
- **\`.github/ISSUE_TEMPLATE/config.yml\`** — disables blank issues and surfaces two contact links: a pointer at \`docs/IMPROVEMENT_PLAN.md\` (so feature requests check the roadmap first) and a pointer at the security-disclosure section in \`CONTRIBUTING.md\`.
- **\`docs/IMPROVEMENT_PLAN.md\`** — marks the community-docs sub-piece shipped; \`CODE_OF_CONDUCT.md\` is the only remaining Phase 4 follow-up.

## Why \`CODE_OF_CONDUCT.md\` is split out

The canonical Contributor Covenant v2.1 text has a \`[INSERT CONTACT METHOD]\` slot for enforcement reports. Filling that in is a maintainer decision (personal email vs. forwarding alias vs. GitHub-only), not a template default — so it lands in its own short follow-up PR after that contact is chosen.

## Test plan

- [x] \`./gradlew spotlessCheck detekt\` clean (pure-doc + workflow-config changes; no Kotlin touched).
- [x] \`.github/ISSUE_TEMPLATE/config.yml\` parses cleanly as YAML.
- [ ] CI \`build_and_test\` and \`instrumented_tests\` green (no source changes, but workflows still run on every PR).
- [ ] After merge: open a fresh issue from the GitHub UI and confirm the new contact links surface alongside the bug-report and feature-request templates, and that "Open a blank issue" is gone.
- [ ] After merge: open a fresh PR (a future one) and confirm the new template prefills the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)