### PR TITLE
docs: add Contributor Covenant v2.1 and close out Phase 4

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/Tarek-Bohdima/ConsultMe/blob/main/docs/IMPROVEMENT_PLAN.md
     about: Before filing a feature request, check the roadmap — your idea may already be tracked under an upcoming phase or intentionally deferred.
   - name: Reporting a security issue
-    url: https://github.com/Tarek-Bohdima/ConsultMe/blob/main/CONTRIBUTING.md#reporting-bugs-and-security-issues
-    about: Please don't open a public issue for security vulnerabilities — see CONTRIBUTING.md for the disclosure path.
+    url: https://github.com/Tarek-Bohdima/ConsultMe/blob/main/SECURITY.md
+    about: Please don't open a public issue for security vulnerabilities — see SECURITY.md for the private "Report a vulnerability" reporting flow.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement. Use the **Report a vulnerability** option in the Security tab. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,10 @@ it when contributing back upstream.
 ## Reporting bugs and security issues
 
 - **Bugs** — use the [bug report issue template](.github/ISSUE_TEMPLATE/bug_report.md).
-- **Security issues** — please don't open a public issue. Email the maintainer
-  privately (see the GitHub profile linked in `LICENSE.md`) so a fix can ship
-  before disclosure.
+- **Security issues** — please don't open a public issue. Use the **Report a
+  vulnerability** option in the repository's Security tab; that opens a private
+  channel visible only to the maintainer. See [`SECURITY.md`](SECURITY.md) for
+  what to expect after submitting.
 
 Thanks again — every PR that makes the template easier to fork helps the next
 adopter.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@ that adopters replace). PRs that improve the template's ergonomics, tooling,
 or documentation are very welcome; PRs that add product features should usually
 land in a fork instead.
 
+## Code of conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+By participating you agree to uphold it.
+
 ## Before you start
 
 1. Open an issue for non-trivial changes (anything beyond a doc/typo fix or a

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -107,8 +107,8 @@ Goal: a fork from this template should be one signing config away from a Play re
 - `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues and surfaces two contact links (the roadmap, and the security-disclosure path documented in `CONTRIBUTING.md`).
 
 **Code of conduct sub-piece (this PR):**
-- `CODE_OF_CONDUCT.md` at the repo root — verbatim Contributor Covenant v2.1, fetched from the canonical source. The enforcement-contact slot is left as the standard `[INSERT CONTACT METHOD]` placeholder for the maintainer to swap in (a project-specific email is planned).
-- `CONTRIBUTING.md` re-links the CoC under a "Code of conduct" section that points at the new file.
+- `CODE_OF_CONDUCT.md` at the repo root — verbatim Contributor Covenant v2.1, fetched from the canonical source. The enforcement-contact slot routes to GitHub's "Report a vulnerability" private flow (the same channel `SECURITY.md` documents in #116) — no email is required anywhere in the project.
+- `CONTRIBUTING.md` re-links the CoC under a "Code of conduct" section, and the "Reporting bugs and security issues" section drops the prior "email the maintainer" wording in favor of the same private Security-tab flow.
 
 ## Phase 5 — Deferred migrations
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -10,7 +10,7 @@ ConsultMe is a Jetpack Compose multi-module Android template. This document is t
 | 1 | Convention plugins (`build-logic/`) | **Done** (#101) |
 | 2 | Template ergonomics (bootstrap script, parameterized header) | **Done** (#104) |
 | 3 | Real example tests | **Done** (#105) |
-| 4 | Production-readiness (R8, CI artifacts, instrumented tests) | **In progress** — CI sub-piece in this PR; R8 + docs follow-ups still open |
+| 4 | Production-readiness (R8, CI artifacts, instrumented tests) | **Done** (#107, #113, #114, #115) |
 | 5 | Deferred migrations (AGP 9, Hilt 2.59+, Kotlin 2.3.20) | Blocked by upstream pin in `dependabot.yml` |
 
 Tick the table when phases land. Each phase below lists scope, rationale, and a rough size; sub-bullets are the concrete deltas.
@@ -86,9 +86,9 @@ Goal: replace the empty `ExampleUnitTest` shells with code that doubles as docum
   - A Compose UI test asserting the screen renders.
 - Each test stays small (≤ 30 lines) — the goal is exemplification, not coverage.
 
-## Phase 4 — Production-readiness (in progress)
+## Phase 4 — Production-readiness (done)
 
-Goal: a fork from this template should be one signing config away from a Play release. Splitting this phase across multiple PRs so each piece can be tuned independently.
+Goal: a fork from this template should be one signing config away from a Play release. Split across four PRs so each piece could be tuned independently.
 
 **CI sub-piece (#107):**
 - `assembleRelease` step in `build_and_test` (catches APK build regressions `test` misses).
@@ -101,13 +101,14 @@ Goal: a fork from this template should be one signing config away from a Play re
 - `:app/proguard-rules.pro` rewritten as a slim starter — the only project-specific rule is `-keepattributes SourceFile,LineNumberTable` (with the matching `-renamesourcefileattribute SourceFile`) so production crashes symbolicate via the `mapping.txt` AGP writes under `build/outputs/mapping/release/`. The platform defaults (`proguard-android-optimize.txt`) plus AAR-shipped consumer rules from Hilt, Compose, Room, and kotlinx.coroutines cover the rest. Comments document when adopters need to add their own keeps (reflective serializers, `Class.forName`, etc.) and point at the [`r8-analyzer`](https://github.com/android/skills) Claude Code skill.
 - Validated locally: `:app:assembleRelease` ships a 896 KB unsigned release APK; `:app:lintRelease` and `./gradlew test` are clean.
 
-**Community docs sub-piece (this PR):**
+**Community docs sub-piece (#114):**
 - `CONTRIBUTING.md` at the repo root — scope statement, local setup, the local CI loop, PR conventions (Conventional Commits, branch protection, one-scope-per-PR), license-header note, repo layout, bug/security reporting paths.
 - `.github/PULL_REQUEST_TEMPLATE.md` — Summary / Test plan / Reviewer notes / Refs sections, mirroring the format the recent PR queue has been using.
 - `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues and surfaces two contact links (the roadmap, and the security-disclosure path documented in `CONTRIBUTING.md`).
 
-**Still open (follow-up PR):**
-- Add a polished `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1). Deferred from this PR because the canonical text needs a real enforcement contact filled in, and that's a maintainer decision rather than a template default.
+**Code of conduct sub-piece (this PR):**
+- `CODE_OF_CONDUCT.md` at the repo root — verbatim Contributor Covenant v2.1, fetched from the canonical source. The enforcement-contact slot is left as the standard `[INSERT CONTACT METHOD]` placeholder for the maintainer to swap in (a project-specific email is planned).
+- `CONTRIBUTING.md` re-links the CoC under a "Code of conduct" section that points at the new file.
 
 ## Phase 5 — Deferred migrations
 


### PR DESCRIPTION
## Summary

- **\`CODE_OF_CONDUCT.md\`** at the repo root — the verbatim Contributor Covenant v2.1, fetched directly from the canonical source at \`https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md\`. The enforcement-contact slot is intentionally left as the standard \`[INSERT CONTACT METHOD]\` placeholder.
- **\`CONTRIBUTING.md\`** — re-adds the "Code of conduct" section that was stubbed out in #114 pending this file.
- **\`docs/IMPROVEMENT_PLAN.md\`** — marks Phase 4 as **Done** (CI #107, R8 #113, community docs #114, CoC this PR).

## Action required before this is "real"

\`[INSERT CONTACT METHOD]\` is currently a literal placeholder in \`CODE_OF_CONDUCT.md\`. Swap it for the project's enforcement email when that address exists (planned: a dedicated project email rather than a personal one). Single-line edit, no other changes needed.

## Test plan

- [x] \`./gradlew spotlessCheck detekt\` clean (pure-doc PR; no Kotlin touched).
- [x] \`grep "INSERT CONTACT METHOD" CODE_OF_CONDUCT.md\` returns exactly one match (verifies the placeholder survived the fetch).
- [x] \`CODE_OF_CONDUCT.md\` structure matches CC v2.1: Pledge / Standards / Enforcement Responsibilities / Scope / Enforcement / Enforcement Guidelines (Correction → Warning → Temporary Ban → Permanent Ban) / Attribution.
- [ ] CI \`build_and_test\` and \`instrumented_tests\` green (no source changes, but workflows still run).
- [ ] After merge: GitHub's Insights → Community Standards page should now show all the green checkmarks (README, License, CoC, Contributing, Issue templates, PR template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)