### PR TITLE
Revise security policy for version support and reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+This project is maintained on a rolling basis. Only the latest version on the `main` branch is actively supported with security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| main    | ✅        |
+| older   | ❌        |
+
+---
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it using GitHub's private reporting feature:
+
+- Go to the **Security** tab of this repository
+- Click **"Report a vulnerability"**
+- Submit the details privately
+
+This ensures that the report is only visible to the maintainer and handled confidentially.
+
+### What to expect
+
+- **Acknowledgment:** within a few days
+- **Assessment:** the issue will be reviewed and validated
+- **Resolution:** a fix will be prepared and released if confirmed
+- **Disclosure:** details will be shared publicly after a fix is available, if appropriate
+
+Please avoid disclosing vulnerabilities publicly until they have been addressed.
+
+---
+
+Thank you for helping improve the security of this project.


### PR DESCRIPTION
Updated the security policy to reflect current version support and reporting process.

## Summary

<!--
  What does this PR change, and why? 1-3 bullets is plenty. Lead with the
  user/adopter-visible effect; cite the roadmap phase if relevant
  (docs/IMPROVEMENT_PLAN.md).
-->

-

## Test plan

<!--
  What did you run locally, and what will CI validate? Check off as you go.
  The repo's local CI loop is documented in CONTRIBUTING.md.
-->

- [ ] `./gradlew spotlessCheck detekt` clean
- [ ] `./gradlew :app:lintRelease` clean (or baseline regenerated)
- [ ] `./gradlew test` clean
- [ ] `./gradlew :app:assembleRelease` succeeds (if touching app/build config or release variant)
- [ ] CI `build_and_test` and `instrumented_tests` green

## Notes for reviewers

<!--
  Optional. Anything that makes the diff easier to review: ordering hints,
  links to upstream changelogs (for dep bumps), known follow-ups deliberately
  left out of scope, screenshots, before/after build output.
-->

## Refs

<!-- Closes #N, refs #N, related to docs/IMPROVEMENT_PLAN.md "Phase X". -->
