### PR TITLE
build: migrate `-Xcontext-receivers` → `-Xcontext-parameters` (unpins Kotlin 2.3.20+)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,19 +38,6 @@ updates:
         versions: [">=2.59"]
       - dependency-name: "com.google.dagger:hilt-android-gradle-plugin"
         versions: [">=2.59"]
-      # Kotlin 2.3.20+ promotes -Xcontext-receivers from warning to a hard
-      # error in release variants, breaking compileReleaseKotlin in
-      # :core-testing and the feature module. Hold until the migration to
-      # -Xcontext-parameters is done (tracked in docs/IMPROVEMENT_PLAN.md).
-      - dependency-name: "org.jetbrains.kotlin.android"
-        versions: [">=2.3.20"]
-      - dependency-name: "org.jetbrains.kotlin.plugin.compose"
-        versions: [">=2.3.20"]
-      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
-        versions: [">=2.3.20"]
-      - dependency-name: "org.jetbrains.kotlin:compose-compiler-gradle-plugin"
-        versions: [">=2.3.20"]
-
     # Group related dependency updates into single pull requests
     groups:
       # Group all Gradle and build plugin updates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,6 @@ Active ignore rules in `.github/dependabot.yml` — leave these alone unless doi
 
 - `com.android.application` / `com.android.library` major versions blocked. AGP 9.x removes the `kotlin-android` plugin requirement and forces Gradle ≥ 9.4 — handle as a dedicated migration PR, not a bot bump.
 - `com.google.dagger.hilt.android` `>=2.59` blocked. Hilt 2.59 hard-requires AGP 9.
-- `org.jetbrains.kotlin.android` and `org.jetbrains.kotlin.plugin.compose` `>=2.3.20` blocked. Kotlin 2.3.20+ promotes `-Xcontext-receivers` from a warning to a hard error in release variants — unblocking is gated on the `-Xcontext-receivers` → `-Xcontext-parameters` migration tracked in `docs/IMPROVEMENT_PLAN.md` "Known follow-ups."
 
 ## Recommended Claude Code skills
 

--- a/build-logic/convention/src/main/kotlin/com/thecompany/consultme/buildlogic/AndroidExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/thecompany/consultme/buildlogic/AndroidExtensions.kt
@@ -22,7 +22,7 @@ internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension<*, 
         jvmToolchain(17)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
-            freeCompilerArgs.set(listOf("-Xcontext-receivers"))
+            freeCompilerArgs.set(listOf("-Xcontext-parameters"))
         }
     }
 }

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -116,12 +116,14 @@ Currently silenced in `.github/dependabot.yml`. Each is its own dedicated PR, no
 
 - **AGP 8.x → 9.x.** Drops the `kotlin-android` plugin requirement and forces Gradle ≥ 9.4. Touches every module's plugin block. Requires removing `alias(libs.plugins.kotlin.android)` and verifying Compose/KSP/Hilt all play nicely with AGP 9's bundled Kotlin support. The official [`agp-9-upgrade`](https://github.com/android/skills) Claude Code skill is a ready-made playbook for this migration.
 - **Hilt 2.59+.** Hard-requires AGP 9; do this in the same PR or a follow-up to the AGP 9 migration.
-- **Kotlin 2.3.20+.** Promotes `-Xcontext-receivers` from a warning to a hard error in release variants — `compileReleaseKotlin` fails in `:core-testing` and the feature module. Both 2.3.20 and 2.3.21 hit this. Unpinning is gated on the `-Xcontext-receivers` → `-Xcontext-parameters` migration below.
 
 ## Known follow-ups not yet phased
 
-- **`-Xcontext-receivers` is deprecated** (every module sets this in `freeCompilerArgs`). Kotlin compiler warns: replace with `-Xcontext-parameters` and migrate to the new syntax. Already a hard error on Kotlin 2.3.20+ release variants — **this migration is what unblocks the Kotlin 2.3.20+ pin in `dependabot.yml`**. The migration is mechanical, but worth verifying nothing in Compose/Hilt-generated code uses receivers.
 - **KSP `2.3.4` lags Kotlin `2.3.10`.** Dependabot will likely propose a bump on the next run; let it.
+
+## Recently shipped follow-ups
+
+- **`-Xcontext-receivers` → `-Xcontext-parameters`** (tracked in issue #117). The flag is set in one place — `build-logic/.../AndroidExtensions.kt` — and no source code uses `context(...)` syntax, so the migration was a one-line swap. This unblocked the `org.jetbrains.kotlin.*` `>=2.3.20` pin in `.github/dependabot.yml`; the next bot run can propose the Kotlin bump.
 
 ## Quality bets to consider (no phase yet)
 


### PR DESCRIPTION
## Summary

- Swap `-Xcontext-receivers` for `-Xcontext-parameters` in `consultme.android.application`/`library` convention plugins (one line in `build-logic/.../AndroidExtensions.kt`). Every module inherits the change via build-logic — no per-module edits needed.
- Drop the four `org.jetbrains.kotlin.*` `>=2.3.20` entries from `.github/dependabot.yml`. This was the last gate on the Kotlin upgrade; the next bot run can propose the bump as a normal grouped PR.
- Tidy CLAUDE.md "Dependency management" and `docs/IMPROVEMENT_PLAN.md` (Phase 5 / Known follow-ups / new "Recently shipped follow-ups" section).

Source-level audit: zero `context(...)` declarations in the repo (verified by `grep -rn "context(" --include="*.kt"`). Migration is purely the compiler flag rename.

AGP 9 + Hilt 2.59 ignores are unchanged — those remain Phase 5.

## Test plan

- [x] `./gradlew spotlessCheck` — pass
- [x] `./gradlew detekt` — pass
- [x] `./gradlew test` — pass (all unit tests, debug + release variants)
- [x] `./gradlew lintRelease` — pass
- [x] `./gradlew assembleRelease` — pass (this was the original failure mode the pin was guarding against)
- [ ] CI green
- [ ] Verify next Dependabot run proposes the Kotlin bump (post-merge, follow-up)

## Refs

Closes #117. Tracked in `docs/IMPROVEMENT_PLAN.md` "Recently shipped follow-ups".

🤖 Generated with [Claude Code](https://claude.com/claude-code)