### PR TITLE
docs+test: address external review feedback (ARCHITECTURE.md, stateful screen test, catalog-sync comment)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,145 @@
+# Architecture
+
+ConsultMe follows a **layered, multi-module** architecture aligned with Google's [`android/nowinandroid`](https://github.com/android/nowinandroid). Each layer has a clear seam, and modules communicate only through public APIs.
+
+## Layers
+
+```mermaid
+graph TD
+    subgraph Presentation
+        APP[":app"]
+        FEAT[":feature-*"]
+        DS[":core-designsystem"]
+        UI[":core-ui"]
+    end
+    subgraph Domain
+        DOM[":core-domain"]
+        MOD[":core-model"]
+    end
+    subgraph Data
+        DAT[":core-data"]
+        DB[":core-database"]
+    end
+    subgraph Cross-cutting
+        COM[":core-common"]
+        TST[":core-testing"]
+    end
+
+    APP --> FEAT
+    APP --> DS
+    APP --> UI
+    FEAT --> DS
+    FEAT --> UI
+    FEAT --> DOM
+    DOM --> MOD
+    DAT --> DB
+    DAT --> MOD
+```
+
+The Presentation layer is Android. The Domain layer and `:core-common` are **pure-Kotlin** modules (`consultme.jvm.library`) — no Android SDK on the classpath, so framework imports won't compile there. The Data layer is Android (Room).
+
+`./gradlew moduleGraph` regenerates [`docs/MODULE_GRAPH.md`](docs/MODULE_GRAPH.md) — that file reflects the actual dep tree, including the `:baselineprofile` producer→`:app` consumer relationship.
+
+## Module responsibilities
+
+| Module | Layer | Belongs here | Doesn't belong |
+|---|---|---|---|
+| `:app` | Presentation root | `Application` class, navigation graph, top-level wiring, Hilt entry point | Screen logic — push to `:feature-*` |
+| `:feature-*` | Presentation | Screens, ViewModels, screen-specific state and side-effects | Cross-feature shared composables (use `:core-ui`) |
+| `:core-designsystem` | Presentation | Theme (`ConsultMeTheme`), color/typography/icon registries | Stateful composables, business logic |
+| `:core-ui` | Presentation | Cross-feature stateless composables (loading, empty, error states, etc.) | Domain types, business logic |
+| `:core-domain` | Domain (pure Kotlin) | Use-cases (`Get*UseCase`, `Update*UseCase`, etc.) | Android types, framework dependencies |
+| `:core-model` | Domain (pure Kotlin) | Pure data classes / sealed types | Logic, side-effects, persistence concerns |
+| `:core-data` | Data | Repositories, DTO ↔ domain mappers, network/database orchestration | Database tables (those are in `:core-database`) |
+| `:core-database` | Data | Room entities, DAOs, database class | Repository APIs (those live in `:core-data`) |
+| `:core-common` | Cross-cutting (pure Kotlin) | Dispatchers, qualifiers, generic utilities | Anything Android-specific |
+| `:core-testing` | Cross-cutting | Test fixtures, dispatcher rule, Hilt test runner | Production code |
+| `:baselineprofile` | Build-only producer | `BaselineProfileGenerator`, `StartupBenchmarks` | Anything that ships in `:app`'s release APK except `baseline-prof.txt` |
+
+## Data flow (UDF)
+
+A typical interaction — user taps a button, screen reflects new state:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Screen as Screen (@Composable)
+    participant VM as ViewModel
+    participant UC as UseCase
+    participant Repo as Repository
+    participant DS as DataSource (Room)
+
+    User->>Screen: tap button
+    Screen->>VM: onEvent()
+    VM->>UC: invoke(...)
+    UC->>Repo: getX(...)
+    Repo->>DS: query(...)
+    DS-->>Repo: Flow<Entity>
+    Repo-->>UC: Flow<DomainModel>
+    UC-->>VM: Flow<DomainModel>
+    VM->>VM: update _uiState (StateFlow)
+    VM-->>Screen: collectAsStateWithLifecycle re-emits
+    Screen->>User: recompose with new state
+```
+
+State is **unidirectional**:
+
+- **Events flow down** (`Screen → VM → UseCase → Repo → DataSource`).
+- **State flows up** (`Repo → UseCase → VM → Screen`) as `Flow<T>`, lifted to `StateFlow<T>` at the VM boundary so Compose can collect with lifecycle awareness.
+
+The `:feature-example` module ships a worked example of this pattern at minimal scope: `ExampleViewModel` exposes a `StateFlow<ExampleUiState>` and `onClicked()`, and `ExampleScreen` collects via `collectAsStateWithLifecycle()`.
+
+## Stateless / stateful screen split
+
+Each feature exposes **two overloads**:
+
+```kotlin
+// Stateful — used by the host activity / nav graph. Pulls a hilt-managed ViewModel.
+@Composable
+fun ExampleScreen(modifier: Modifier = Modifier, viewModel: ExampleViewModel = hiltViewModel())
+
+// Stateless — used by `@Preview` and Compose UI tests. No ViewModel coupling.
+@Composable
+fun ExampleScreen(uiState: ExampleUiState, onClick: () -> Unit, modifier: Modifier = Modifier)
+```
+
+Why both:
+
+- **Previews** can render every UI state without a Hilt graph — pass `ExampleUiState.Clicked`, see what it looks like.
+- **UI tests** of the stateless overload (`ExampleScreenTest`) are a one-liner: drive state via the parameter, assert what's on screen.
+- **Stateful tests** (`ExampleScreenStatefulTest`) construct a real `ExampleViewModel` instance and pass it as `viewModel = ...`, exercising the full screen↔VM round-trip without needing Hilt.
+
+## Navigation
+
+Navigation is owned by `:app` — it's the only module that knows about every feature. Each feature exposes a public composable entry point and a route:
+
+```kotlin
+// :feature-example
+@Composable fun ExampleScreen(...)
+fun NavGraphBuilder.exampleScreen() { composable<ExampleRoute> { ExampleScreen() } }
+
+// :app
+NavHost(...) {
+    exampleScreen()
+    // otherFeatureScreen()
+}
+```
+
+Adopters add destinations the same way. **Never reach into a feature's internal composables** from `:app` or another feature — go through the public route extension.
+
+## Why pure-Kotlin domain layers
+
+`:core-model`, `:core-domain`, and `:core-common` use `consultme.jvm.library`, not `android.library`. Trade-off:
+
+- **Build speed**: 5–10× faster compilation (no AGP, no resource processing, no R class).
+- **Discipline**: Android SDK isn't on the classpath, so `import android.*` won't compile. Forces clean separation of concerns.
+- **Test speed**: pure JUnit, no Robolectric or instrumentation needed.
+
+The cost: Hilt `@Provides` modules (which reference `dagger.hilt.components.SingletonComponent`) live in `:app` or `:core-data`, not in `:core-common`. The qualifier *annotations* (`@Dispatcher(IO)`) live in `:core-common`; the *bindings* live next to the consumer.
+
+## Cross-cutting conventions
+
+- **Dispatchers**: `@Dispatcher(AppDispatchers.IO)` qualifier from `:core-common`. Adopters provide the binding (`@Provides @Dispatcher(IO) fun providesIo() = Dispatchers.IO`) wherever they apply Hilt.
+- **State**: `Flow<T>` for streams, `Result<T>` for one-shot operations. Domain layer surfaces `Flow<DomainModel>` / `Result<DomainModel>`, never raw DTOs or `Response<T>`.
+- **Theme**: feature modules pull `:core-designsystem` automatically via the `consultme.android.feature` convention plugin — don't redeclare.
+- **Coverage**: Kover instruments every module that applies an `consultme.android.*` or `consultme.jvm.library` convention. Generated Hilt/Room/Compose code is excluded in `consultme.kover.gradle.kts` so the metric reflects real coverage.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Tags follow SemVer with a template-adopter lens: **MAJOR** = breaking change for
 
 | File | What's in it |
 |---|---|
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | Layered module diagram, UDF data-flow sequence, module responsibilities table, navigation/dispatcher conventions. Read this first if you're orienting in the codebase. |
 | [`CLAUDE.md`](CLAUDE.md) | Orientation for AI coding assistants and humans — common commands, module graph, conventions, CI / branch protection, versioning policy. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Local setup, the local CI loop, PR conventions, license header, where things live, bug/security reporting paths. |
 | [`docs/IMPROVEMENT_PLAN.md`](docs/IMPROVEMENT_PLAN.md) | Living roadmap. Every phase has state, scope, rationale, and concrete deltas. Read before non-trivial work. |

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -9,6 +9,12 @@ kotlin {
     jvmToolchain(17)
 }
 
+// Every `libs.*` accessor below pulls from `gradle/libs.versions.toml` — the
+// same catalog every module uses. Keeping `build-logic`'s plugin classpath
+// in lockstep with the catalog (rather than declaring versions here directly)
+// is what prevents version drift between the conventions and the modules
+// they configure, and is what makes Dependabot's grouped updates affect both
+// layers atomically.
 dependencies {
     compileOnly(libs.android.gradle.plugin)
     compileOnly(libs.kotlin.gradle.plugin)

--- a/feature-example/src/androidTest/java/com/thecompany/consultme/feature/example/ui/ExampleScreenStatefulTest.kt
+++ b/feature-example/src/androidTest/java/com/thecompany/consultme/feature/example/ui/ExampleScreenStatefulTest.kt
@@ -1,0 +1,54 @@
+// Copyright 2026 MyCompany
+package com.thecompany.consultme.feature.example.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Demonstrates the stateful-screen test pattern: pass a real
+ * [ExampleViewModel] instance via the screen's `viewModel = ...` parameter
+ * (avoiding the `hiltViewModel()` default), drive state by calling the
+ * ViewModel's public API, and observe the screen recompose.
+ *
+ * This complements [ExampleScreenTest], which tests the stateless overload
+ * directly (the simpler path). Use this pattern when you want to verify
+ * the round-trip — UI event → ViewModel → state change → recomposition —
+ * without standing up a full Hilt graph.
+ *
+ * For tests that need to mock a Repository or other ViewModel
+ * dependencies, prefer the same shape: construct the ViewModel with fakes
+ * passed to its constructor, then proceed exactly as below. MockK is on
+ * the classpath via `:core-testing` if you need it; this template just
+ * doesn't need it for the placeholder feature.
+ */
+@RunWith(AndroidJUnit4::class)
+class ExampleScreenStatefulTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun screen_reactsToViewModelStateAndForwardsClicks() {
+        val viewModel = ExampleViewModel()
+
+        composeTestRule.setContent {
+            ExampleScreen(viewModel = viewModel)
+        }
+
+        // Idle state renders the placeholder label.
+        composeTestRule
+            .onNodeWithText("Replace this screen with your feature.")
+            .assertIsDisplayed()
+
+        // Tap the button — the stateful screen forwards to viewModel.onClicked().
+        composeTestRule.onNodeWithText("Click me").performClick()
+
+        // The click flips the VM's StateFlow; the screen recomposes against the new state.
+        composeTestRule.onNodeWithText("Clicked!").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Summary

Three independent additions, all small, each addressing a concrete recommendation from a recent external review of the template.

### 1. `ARCHITECTURE.md` at repo root

Layer diagram + module-responsibilities table + UDF data-flow sequence diagram + navigation policy + pure-Kotlin domain rationale + cross-cutting conventions. Mermaid graphs render natively on github.com.

> *Reviewer's recommendation:* "Documentation as Code: Consider adding a `ARCHITECTURE.md` file that visually diagrams the flow between `feature-*` modules and `core-*` modules, particularly how you handle navigation or data state flow across these boundaries."

### 2. `ExampleScreenStatefulTest.kt`

The existing test suite covered:
- `ExampleScreenTest` — stateless overload (no VM)
- `ExampleViewModelTest` — VM in isolation (Turbine)
- `ExampleHiltTest` — Hilt graph wiring

Missing: a test that exercises the **stateful** overload with a real `ExampleViewModel` instance, demonstrating UI-event → VM → state-change → recomposition round-trip without standing up a full Hilt graph. New test fills that gap. Documented as the canonical pattern adopters should reach for when they want to drive a screen's stateful overload through its VM (extending naturally to mocked Repository deps).

> *Reviewer's recommendation:* "Ensure your `ExampleScreen.kt` includes at least one UI test that demonstrates testing a screen with a mocked ViewModel/Repository. This is the most common hurdle for developers using templates."

### 3. `build-logic` catalog-sync explanatory comment

The existing pattern (`compileOnly(libs.*-gradle-plugin)` + the `compileOnly(files(libs.javaClass...))` workaround) already keeps `build-logic` plugin versions in lockstep with the root catalog. Added a comment above the dependencies block making this design intent explicit, so the next maintainer doesn't have to re-derive it from grep output.

> *Reviewer's recommendation:* "Ensure that the `build-logic` plugins remain strictly synced with the root catalog to avoid version drift across modules."

## Test plan

- [x] `./gradlew spotlessCheck` clean
- [x] `./gradlew test` clean
- [x] `./gradlew lintRelease` clean
- [ ] CI `build_and_test` and `instrumented_tests` green

## Out of scope (also from the review)

The reviewer noted the Detekt removal as a "strategic trade-off" — flagged it but didn't push for adding back. Keeping the Spotless+Lint stack as-is per Phase 5's NIA-alignment decision. No action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)