### PR TITLE
docs(README): add Template origin section for upstream-discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ Tags follow SemVer with a template-adopter lens: **MAJOR** = breaking change for
 | [`SECURITY.md`](SECURITY.md) | Security disclosure policy. |
 | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) | Contributor Covenant v2.1. |
 
+## Template origin
+
+Scaffolded from [`Tarek-Bohdima/ConsultMe`](https://github.com/Tarek-Bohdima/ConsultMe) — a Compose multi-module Android template. The upstream tracks plumbing improvements (convention plugins, build infrastructure, dependency migrations, baseline-profile and module-graph tooling) independent of any one fork's product code. If you scaffolded from it, the upstream [Releases](https://github.com/Tarek-Bohdima/ConsultMe/releases) page and [`docs/IMPROVEMENT_PLAN.md`](https://github.com/Tarek-Bohdima/ConsultMe/blob/main/docs/IMPROVEMENT_PLAN.md) are where new tooling and migration playbooks land. The bootstrap script (`scripts/rename-template.py`) skips `.md` files, so this notice survives renames.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.


### PR DESCRIPTION
## Summary

Adds a small \`## Template origin\` section to the README, placed just before \`## License\`. Mirrors the upstream-discoverability pattern Google uses on [\`android/architecture-templates\`](https://github.com/android/architecture-templates) so adopters who scaffolded from this template months ago can answer "is there a newer set of conventions / migrations I should pull?" without remembering the upstream URL.

Tone is deliberately subtle — no badges, no stars-pleas, no "consider sponsoring". One paragraph pointing at:

- The upstream repo
- The Releases page (where new tags land)
- \`docs/IMPROVEMENT_PLAN.md\` (where planned/in-flight work is tracked)

## Why this works for the rename flow

The existing rename script (\`scripts/rename-template.py\`) intentionally skips \`.md\` files — that's already documented in the "How to Rename and Refactor" section. So this notice survives the rename intact for adopters who scaffolded from the template, and adopters who'd rather not keep the pointer can remove the section as part of their post-bootstrap cleanup pass (which already includes "update README badges, replace project description, etc.").

## Test plan

- [x] \`./gradlew spotlessCheck\` clean (Spotless doesn't target \`.md\`, but ran for sanity).
- [ ] CI \`build_and_test\` and \`instrumented_tests\` green (docs-only change, fast pass expected).
- [ ] README renders correctly on github.com (links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)