### PR TITLE
docs: fix stale Phase 5 references that should be Phase 9 (skip-CI test)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Running one test:
 ./gradlew :feature-example:testDebugUnitTest --tests "*ExampleUnitTest.someMethod"
 ```
 
-`spotlessApply` is the autofix; the license header gets injected with the current year and the literal `MyCompany` string. Adopters of the template should rename `MyCompany` in the root `build.gradle.kts` Spotless config (planned to be parameterized in Phase 2 — see `docs/IMPROVEMENT_PLAN.md`).
+`spotlessApply` is the autofix; the license header gets injected with the current year and the value of `template.company` from `gradle.properties` (defaults to `MyCompany`). Adopters override `template.company` once per fork; the bootstrap script (`scripts/rename-template.py`) handles this automatically.
 
 Lint baselines (`<module>/lint-baseline.xml`) exist per module — regenerate with `./gradlew :<module>:updateLintBaseline` rather than hand-editing.
 
@@ -66,7 +66,7 @@ Active ignore rules in `.github/dependabot.yml` — leave these alone unless doi
 
 Google's official Android Claude Code skills live at <https://github.com/android/skills>. Skills relevant to this template:
 
-- `agp-9-upgrade` — playbook for the Phase 5 AGP 8 → 9 migration.
+- `agp-9-upgrade` — playbook for the Phase 9 AGP 8 → 9 migration (shipped in `v4.0.0-rc.1`; the local copy at `.claude/skills/agp-9-upgrade/` stays useful for AGP 10 prep).
 - `r8-analyzer` — helps analyze keep rules when ramping Phase 4 (release minification).
 - `edge-to-edge` — adoption guide if/when the template adopts edge-to-edge.
 
@@ -96,5 +96,5 @@ Tags follow SemVer with a template-adopter lens: a "breaking change" is one that
 **Conventions:**
 - **Tag at phase boundaries** from `docs/IMPROVEMENT_PLAN.md`, not arbitrarily. So Phase 0+1+1polish+2+3 collapse into a single tag; Phase 4 into the next; etc.
 - **Every tag is a GitHub Release** with auto-generated notes, not just a bare git tag. Use `gh release create vX.Y.Z --generate-notes`.
-- **Pre-release suffixes** (`v2.0.0-rc.1`) for the Phase 5 deferred migrations (AGP 9 / Hilt 2.59 / Kotlin 2.3.20+) so adopters can preview before promotion.
+- **Pre-release suffixes** (e.g. `v4.0.0-rc.1`) for the Phase 9 deferred migrations (AGP 9 / Hilt 2.59 / Kotlin 2.3.20+) so adopters can preview before promotion.
 - Old `v1.0.0`–`v1.4.0` tags from August 2025 are pre-roadmap and immutable; they don't map to any current phase. The next tag after Phase 4 wraps will be **`v2.0.0`** (the `minSdk` 25→26 in #105 is breaking for any fork from `v1.4.0`).

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -235,7 +235,7 @@ Google maintains official AI-optimized skills for Android at <https://github.com
 
 | Skill | Use when |
 |---|---|
-| [`agp-9-upgrade`](https://github.com/android/skills) | Working on Phase 5 (AGP 8 → 9 migration) |
+| [`agp-9-upgrade`](https://github.com/android/skills) | Working on Phase 9 (AGP 8 → 9 migration) |
 | [`r8-analyzer`](https://github.com/android/skills) | Working on Phase 4 (release minification, keep rules) |
 | [`edge-to-edge`](https://github.com/android/skills) | Adopting edge-to-edge (see Quality bets) |
 
@@ -247,4 +247,10 @@ When starting a phase, change its row in the status table to **In progress**, li
 
 ## Releases
 
-Cut a GitHub Release at every phase boundary, not arbitrarily. Phase 0–3 collapse into one MAJOR (`v2.0.0`, because Phase 3's `minSdk` 25→26 is breaking for adopters); Phase 4 ships as `v2.1.0` (or another MAJOR if R8 introduces required keep-rule changes for forks); Phase 5 ships as `v3.0.0` since AGP 9 / Hilt 2.59 / Kotlin 2.3.20+ each force adopter migrations. See `CLAUDE.md` "Versioning and tags" for the full policy.
+Cut a GitHub Release at every phase boundary, not arbitrarily. Actual phase → release mapping:
+
+- **Phases 5–7** (NIA-alignment slices 1–3) bundled into `v3.0.0`. MAJOR because slice 2 moved the theme package (`com.thecompany.consultme.ui.theme` → `core.designsystem.theme`) — breaking for forks at v2.x.
+- **Phase 8** (`:baselineprofile` macrobenchmark + pipeline) shipped as `v3.1.0` (additive, non-breaking).
+- **Phase 9** (deferred migrations: AGP 9.2.1 / Hilt 2.59.2) shipped as `v4.0.0-rc.1` (pre-release; promotion to `v4.0.0` blocked on `androidx.baselineprofile` 1.5.x stable).
+
+See `CLAUDE.md` "Versioning and tags" for the full policy.


### PR DESCRIPTION
## Summary

Cleanup of stale Phase-number references that were missed when the NIA-alignment effort renumbered phases (slices 1–4 became phases 5–8; deferred migrations moved to Phase 9).

**Doubles as the verification PR for [#136](https://github.com/Tarek-Bohdima/ConsultMe/pull/136)'s skip-on-docs-only behavior** — both files in this diff (\`CLAUDE.md\` and \`docs/IMPROVEMENT_PLAN.md\`) are \`.md\` files matching the new \`changes\` job's docs classifier. Expected CI behavior:

- \`changes\` job: passes in <5s, outputs \`code=false\`
- \`build_and_test\`: **skipped** (counts as pass for branch protection)
- \`instrumented_tests\`: **skipped**

If both heavy jobs skip cleanly and the PR is mergeable, the gate works end-to-end for adopters.

## Concrete fixes

\`CLAUDE.md\`:
- "rename \`MyCompany\` in the root build.gradle.kts Spotless config (planned to be parameterized in Phase 2)" → updated to reflect Phase 2 already shipped; adopters override \`template.company\` in \`gradle.properties\` now.
- \`agp-9-upgrade\` skill description: "Phase 5 AGP 8 → 9 migration" → "Phase 9 AGP 8 → 9 migration (shipped in v4.0.0-rc.1)".
- Pre-release suffix example: \`v2.0.0-rc.1\` for Phase 5 → \`v4.0.0-rc.1\` for Phase 9.

\`docs/IMPROVEMENT_PLAN.md\`:
- Recommended-skills table: \`agp-9-upgrade\` row says "Working on Phase 5" → "Working on Phase 9".
- Releases section: replaced the original prediction-style paragraph ("Phase 5 ships as v3.0.0") with the actual phase → release mapping (phases 5–7 → \`v3.0.0\`, Phase 8 → \`v3.1.0\`, Phase 9 → \`v4.0.0-rc.1\`).

## Test plan

- [ ] CI \`changes\` job classifies as docs-only (\`code=false\` in step output)
- [ ] CI \`build_and_test\` reports as **skipped** (not failed, not run)
- [ ] CI \`instrumented_tests\` reports as **skipped**
- [ ] PR is mergeable without admin override (skipped == pass for branch protection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)