### PR TITLE
docs(IMPROVEMENT_PLAN): mark Phase 8 and Phase 9 as done

### DIFF
--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -14,8 +14,8 @@ ConsultMe is a Jetpack Compose multi-module Android template. This document is t
 | 5 | NIA-alignment slice 1 (convention plugins expansion, drop Detekt) | **Done** (#123) |
 | 6 | NIA-alignment slice 2 (module scaffolding: `:core-designsystem`, `:core-model`, `:core-common`, `:core-domain`) | **Done** (#124) |
 | 7 | NIA-alignment slice 3 (quality tooling: Kover + module-graph) | **Done** (#126) |
-| 8 | NIA-alignment slice 4 (`:baselineprofile` macrobenchmark + baseline profile) | In progress (#122) |
-| 9 | Deferred migrations (AGP 9, Hilt 2.59+, Kotlin 2.3.20) | In progress (#131) |
+| 8 | NIA-alignment slice 4 (`:baselineprofile` macrobenchmark + baseline profile) | **Done** (#129, `v3.1.0`) |
+| 9 | Deferred migrations (AGP 9, Hilt 2.59+, Kotlin 2.3.20) | **Done** (#132, `v4.0.0-rc.1`) |
 
 Tick the table when phases land. Each phase below lists scope, rationale, and a rough size; sub-bullets are the concrete deltas.
 
@@ -184,7 +184,7 @@ Tracking: #122.
 
 - Initial baseline profile bytes need to be generated locally before forks see startup benefits. The `app/src/main/baseline-prof.txt` file is committed as a stub on the first run after a real device run. Document in CONTRIBUTING.md.
 
-## Phase 9 — Deferred migrations (in progress)
+## Phase 9 — Deferred migrations (done)
 
 Goal: pull the template onto the AGP 9 / Hilt 2.59+ tooling line. Kotlin 2.3.20+ already unpinned in #118.
 


### PR DESCRIPTION
## Summary

Phase 8 (\`:baselineprofile\` macrobenchmark + pipeline) shipped in PR #129 as \`v3.1.0\`. Phase 9 (AGP 9.2.1 + Hilt 2.59.2) shipped in PR #132 as \`v4.0.0-rc.1\`. The status table and Phase 9 section heading still showed both as "In progress" — fixing.

| | Before | After |
|---|---|---|
| Phase 8 row | \`In progress (#122)\` | \`Done (#129, \`v3.1.0\`)\` |
| Phase 9 row | \`In progress (#131)\` | \`Done (#132, \`v4.0.0-rc.1\`)\` |
| Phase 9 heading | \`(in progress)\` | \`(done)\` |

## Doubles as the verification PR for #138

The diff is **one .md file under \`docs/\`** — matches both \`\\.md\$\` and \`^docs/\` exclusions in the \`changes\` classifier (used by both \`android_ci.yml\` and the new \`codeql.yml\`). Expected check list:

- \`changes\` (Android CI): pass <5s, \`code=false\`
- \`build_and_test\`: **skipped**
- \`instrumented_tests\`: **skipped**
- \`changes\` (CodeQL): pass <5s, \`code=false\`
- \`Analyze (actions)\`: **skipped**
- \`Analyze (java-kotlin)\`: **skipped** ← the 10-minute one
- \`Analyze (python)\`: **skipped**

Total wall-clock should drop from ~10 minutes to <30 seconds for the docs-only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)