### PR TITLE
ci: tighten docs-classifier regex (close defense-in-depth gap)

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -51,10 +51,19 @@ jobs:
           changed=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
           echo "Changed files in PR #${PR_NUMBER}:"
           printf '  %s\n' "$changed"
-          # Anything that's NOT a .md file, NOT under docs/ or
-          # .github/ISSUE_TEMPLATE/, and NOT a LICENSE* counts as "code".
+          # Defense-in-depth: classify by *extension* AND path, not path
+          # alone. The previous `^LICENSE`/`^docs/`/`^\.github/ISSUE_TEMPLATE/`
+          # prefix patterns would have skipped CI for an attacker-named
+          # `LICENSE.kt`, `docs/exploit.kts`, or
+          # `.github/ISSUE_TEMPLATE/Foo.gradle.kts`. The tightened regex:
+          #   - Skips any file ending in `.md` (anywhere).
+          #   - Skips bare `LICENSE` / `LICENSE.md` / `LICENSE.txt` only.
+          #   - Skips `.yml`/`.yaml` files only when they live under
+          #     `.github/ISSUE_TEMPLATE/`.
+          # Anything else — including `.kt`/`.kts` masquerading as docs —
+          # runs the full gradle gate.
           code=$(printf '%s\n' "$changed" \
-            | grep -vE '(\.md$|^LICENSE|^docs/|^\.github/ISSUE_TEMPLATE/)' \
+            | grep -vE '(\.md$|^LICENSE(\.md|\.txt)?$|^\.github/ISSUE_TEMPLATE/.*\.ya?ml$)' \
             || true)
           if [ -n "$code" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,8 +55,12 @@ jobs:
           changed=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
           echo "Changed files in PR #${PR_NUMBER}:"
           printf '  %s\n' "$changed"
+          # Defense-in-depth: same tightened classifier as `android_ci.yml`.
+          # Skips by extension + path, not path prefix alone, so an attacker-
+          # named `LICENSE.kt` / `docs/exploit.kts` / non-yaml file under
+          # `.github/ISSUE_TEMPLATE/` runs the full analyze matrix.
           code=$(printf '%s\n' "$changed" \
-            | grep -vE '(\.md$|^LICENSE|^docs/|^\.github/ISSUE_TEMPLATE/)' \
+            | grep -vE '(\.md$|^LICENSE(\.md|\.txt)?$|^\.github/ISSUE_TEMPLATE/.*\.ya?ml$)' \
             || true)
           if [ -n "$code" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Tightens the docs-classifier regex used by both \`android_ci.yml\` and \`codeql.yml\` to match by **extension + path** rather than path prefix alone. Closes the defense-in-depth gap surfaced in the security review: an attacker-named file like \`LICENSE.kt\`, \`docs/exploit.kts\`, or \`.github/ISSUE_TEMPLATE/Foo.gradle.kts\` would have skipped CI under the old prefix patterns.

| | Before | After |
|---|---|---|
| Regex | \`(\\.md\$\|^LICENSE\|^docs/\|^\\.github/ISSUE_TEMPLATE/)\` | \`(\\.md\$\|^LICENSE(\\.md\|\\.txt)?\$\|^\\.github/ISSUE_TEMPLATE/.*\\.ya?ml\$)\` |

## Behavior table

Skips CI (docs):
- Any \`.md\` file anywhere
- \`LICENSE\` (no extension), \`LICENSE.md\`, \`LICENSE.txt\` **only**
- \`.github/ISSUE_TEMPLATE/**.yml\` and \`*.yaml\` **only**

Runs full CI (code):
- \`LICENSE.kt\`, \`LICENSEexploit.kts\` ← was the gap
- \`docs/exploit.kts\` and any non-\`.md\` under \`docs/\` ← was the gap
- \`.github/ISSUE_TEMPLATE/*.gradle.kts\` ← was the gap
- All workflow yamls (\`.github/workflows/**\`), \`gradle.properties\`, \`.kt\`, \`.kts\`, etc. ← unchanged

## Local sanity test

Ran the new regex against 15 representative paths — all classifications correct, including the three previous gap exploits. Output included in the commit message body.

## CI behavior on this PR

This PR touches \`.github/workflows/\` (which is correctly classified as **code**), so the full CI runs on it — \`build_and_test\`, \`instrumented_tests\`, \`Analyze (actions/java-kotlin/python)\`. That's the right outcome: workflow changes deserve scanning.

Verification of the tightened regex on a real docs-only path comes on the next docs-only PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)