### PR TITLE
feat(scripts): add Bootstrap from template workflow_dispatch action

### DIFF
--- a/.github/workflows/bootstrap-from-template.yml
+++ b/.github/workflows/bootstrap-from-template.yml
@@ -1,0 +1,64 @@
+name: Bootstrap from template
+
+# One-shot rename helper for adopters who created a repo via "Use this template".
+# Mirrors `scripts/rename-template.py`; self-deletes once the rename commit lands so
+# the workflow doesn't keep haunting the adopter's Actions tab. The local script
+# stays available for offline / branch-protected adoption flows.
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'New package (e.g. com.acme.myapp)'
+        required: true
+        type: string
+      app_name:
+        description: 'New app display name (e.g. My App)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      # Guard so a stray click on the upstream template doesn't rewrite it.
+      - name: Refuse to run on the upstream template
+        if: github.repository == 'Tarek-Bohdima/ConsultMe'
+        run: |
+          echo "::error::This is the upstream template repository — Bootstrap is for downstream repos only."
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.x'
+
+      - name: Run rename script
+        env:
+          PACKAGE: ${{ inputs.package }}
+          APP_NAME: ${{ inputs.app_name }}
+        run: python3 scripts/rename-template.py "$PACKAGE" "$APP_NAME"
+
+      - name: Self-delete bootstrap workflow
+        run: git rm .github/workflows/bootstrap-from-template.yml
+
+      - name: Commit and push
+        env:
+          PACKAGE: ${{ inputs.package }}
+          APP_NAME: ${{ inputs.app_name }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::warning::No changes to commit. The script may have already been run."
+            exit 0
+          fi
+          git commit -m "chore: bootstrap from template (package=$PACKAGE, app=$APP_NAME)"
+          git push

--- a/README.md
+++ b/README.md
@@ -37,7 +37,21 @@ Do not clone this repository directly. The recommended way to use this template 
 
 ## How to Rename and Refactor
 
-After creating your new repository, run the bootstrap script — it does the package, namespace, `applicationId`, project name, theme/application class, manifest, and `app_name` rewrites in one pass:
+There are two equivalent paths — pick whichever fits your workflow. Both run the same `scripts/rename-template.py` under the hood, so they produce the same result.
+
+### Option A: One click in the GitHub UI
+
+After creating your new repo via **Use this template**, a one-shot helper sits in your Actions tab:
+
+1. Open your new repo on GitHub.
+2. Go to **Actions → Bootstrap from template → Run workflow**.
+3. Fill in **package** (e.g. `com.acme.myapp`) and **app name** (e.g. `My App`) and click **Run workflow**.
+
+The workflow runs the rename script with your inputs, commits the result directly to your default branch, and self-deletes itself in the same commit so it doesn't keep haunting your Actions tab. If your repo has branch protection on the default branch, the push will be rejected — use Option B instead, or temporarily relax protection.
+
+### Option B: Locally with Python
+
+If you'd rather rename offline, run the same script on your machine:
 
 ```bash
 python3 scripts/rename-template.py com.acme.myapp "My App Name"
@@ -45,13 +59,14 @@ python3 scripts/rename-template.py com.acme.myapp "My App Name"
 
 The first argument is the new package (also used as `applicationId`). The second is the user-facing app name; its PascalCase form (`MyAppName`) becomes `rootProject.name`, the theme name, and the `Application` class name. The four convention plugin IDs under `build-logic/` are also rewritten (`consultme.android.*` → `myappname.android.*`). Re-running with the same arguments is a no-op.
 
-After the script completes, finish the bootstrap by hand:
+The script also scrubs three template-maintainer-personal files so they don't carry the upstream owner's identity into your repo: `.github/FUNDING.yml` is deleted, the `reviewers`/`assignees` blocks in `.github/dependabot.yml` are stripped, and `.github/ISSUE_TEMPLATE/config.yml` is rewritten to a commented `contact_links` stub. Re-add your own once your fork has a public URL.
+
+### Post-bootstrap steps (both options)
 
 1. **License header company name:** open `gradle.properties` and set `template.company` (consumed by the root `build.gradle.kts` Spotless config). Then run `./gradlew spotlessApply` to rewrite every header.
 2. **License file:** open `LICENSE.md` and replace `[year]` and the placeholder name with your own.
 3. **README and docs:** update the badges (CI, stars, forks) to point at your repo, and replace the project description in this file. The script intentionally skips `*.md` so it doesn't break upstream-template links.
 4. **Feature module:** replace the placeholder content in `:feature-example` (start with `ExampleScreen.kt`), and rename the module (`:feature-example` → `:feature-yourname`) once you know what you're building.
-5. **Remove template funding file:** delete `.github/FUNDING.yml`, or replace it with your own sponsorship info.
 
 If you'd rather rename by hand, expand the manual fallback below.
 
@@ -66,7 +81,11 @@ Use Android Studio's **Refactor > Rename** for the package step.
 4. **Theme + application class:** rename `ConsultMeTheme`, `Theme.ConsultMe` (in `app/src/main/res/values/themes.xml`), and `ConsultMeApplication` (class + filename + `AndroidManifest.xml` reference) to match your new project name.
 5. **App display name:** in `app/src/main/res/values/strings.xml`, change `app_name`.
 6. **Convention plugin IDs:** rename the four files under `build-logic/convention/src/main/kotlin/consultme.android.*.gradle.kts` and update every `id("consultme.android.*")` reference in module build scripts.
-7. Then continue with the post-script steps above (license header, LICENSE file, README badges, feature module, FUNDING.yml).
+7. **Maintainer-personal files** (Options A and B do this for you; manual renamers need to do it explicitly):
+    - Delete `.github/FUNDING.yml`.
+    - Strip the `reviewers`/`assignees` blocks from `.github/dependabot.yml`.
+    - Replace the `contact_links` URLs in `.github/ISSUE_TEMPLATE/config.yml` with your own (or delete them).
+8. Then continue with the post-bootstrap steps above.
 
 </details>
 

--- a/scripts/rename-template.py
+++ b/scripts/rename-template.py
@@ -23,6 +23,9 @@ Performs in one pass:
   .github/ISSUE_TEMPLATE/config.yml contact_links to a commented stub.
   Each step is gated on the maintainer handle still being present, so
   re-running after manual customization leaves adopter content alone.
+- One-shot cleanup: removes .github/workflows/bootstrap-from-template.yml
+  if it's still around — that workflow is the UI-equivalent of this
+  script and is no longer needed once the rename has run.
 
 Scope: rewrites .kt, .kts, .xml, .toml, .properties files only. README,
 CLAUDE.md, LICENSE.md, and docs/ are intentionally skipped — they contain
@@ -145,10 +148,11 @@ def rename_plugin_files(root: Path, old_slug: str, new_slug: str) -> None:
 
 
 def scrub_template_owner_files(root: Path) -> list[str]:
-    """Remove the template maintainer's identity from files GitHub copies into every fork.
+    """Remove maintainer-personal files plus one-shot bootstrap helpers.
 
-    Idempotent: each step is gated on the maintainer handle still being present,
-    so re-running after manual customization leaves adopter content alone.
+    Idempotent: each maintainer-handle step is gated on the handle still being
+    present, and the one-shot deletions are gated on file existence. Re-running
+    after manual customization is a no-op.
     """
     actions: list[str] = []
 
@@ -175,6 +179,13 @@ def scrub_template_owner_files(root: Path) -> list[str]:
     if issue_config.exists() and TEMPLATE_OWNER_HANDLE in issue_config.read_text(encoding="utf-8"):
         issue_config.write_text(ISSUE_TEMPLATE_CONFIG_STUB, encoding="utf-8")
         actions.append("rewrote .github/ISSUE_TEMPLATE/config.yml contact_links to a commented stub")
+
+    # The UI bootstrap workflow self-deletes after a successful run; mirror that
+    # behavior here so local-script adopters end up with the same clean state.
+    bootstrap_workflow = root / ".github" / "workflows" / "bootstrap-from-template.yml"
+    if bootstrap_workflow.exists():
+        bootstrap_workflow.unlink()
+        actions.append("deleted .github/workflows/bootstrap-from-template.yml (one-shot helper)")
 
     return actions
 


### PR DESCRIPTION
## Summary

Adds a one-shot GitHub Actions workflow that runs `scripts/rename-template.py` via the Actions UI, so template adopters can rename without leaving the browser. The local script remains the source of truth and is documented as Option B for offline / branch-protected adoption flows.

- New `.github/workflows/bootstrap-from-template.yml` — `workflow_dispatch` with `package` and `app_name` inputs. Runs the rename script with the inputs as env vars (no shell-injection from `${{ inputs.* }}`), self-deletes the workflow file in the commit, pushes to default branch.
- Guard step refuses to run on `Tarek-Bohdima/ConsultMe` itself so a stray click on the upstream template can't rewrite the source.
- `scripts/rename-template.py` mirrors the self-delete: also removes `.github/workflows/bootstrap-from-template.yml` if present, so local-script adopters end up with the same clean state as UI-flow adopters. Idempotent — gated on file existence.
- README "How to Rename and Refactor" restructured into Option A (UI) / Option B (local) / shared post-bootstrap steps. The manual-rename fallback gains an explicit step 7 for the maintainer-personal files (FUNDING.yml, dependabot reviewers, ISSUE_TEMPLATE config) that the script normally scrubs, so manual renamers don't quietly inherit them.

## Test plan

- [x] Dry-run scrub on a temp `.github/` copy: bootstrap workflow file is deleted alongside FUNDING.yml / dependabot blocks / config.yml; re-run is a no-op.
- [x] SHA pin on `actions/setup-python` matches the latest stable release (`a309ff8b…` / v6.2.0).
- [x] Inputs piped via env vars (`PACKAGE`, `APP_NAME`) rather than `${{ }}` shell substitution.
- [x] Guard step would block execution on the upstream template repo (`github.repository == 'Tarek-Bohdima/ConsultMe'`).
- [ ] CI: spotless / lint / tests / CodeQL Actions analyzer pass on this branch.

## Notes

The workflow needs `contents: write` to push the rename commit to the default branch. On a fresh "Use this template" repo there's no branch protection (it's not copied from the template), so the push just works. Adopters who've already enabled branch protection get a clear push-rejection error and fall back to Option B (local script).

The bootstrap workflow itself never runs on this repo before merge — `workflow_dispatch` is opt-in, and the guard would block it anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)