### PR TITLE
chore: ignore Python __pycache__ from scripts/ helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,11 @@ $RECYCLE.BIN/
 hs_err_pid*
 replay_pid*
 
+# === Python ===
+# Bytecode caches from scripts/ helpers
+__pycache__/
+*.pyc
+
 # === AI tooling ===
 # Claude Code local state (settings, scheduled task locks)
 .claude/


### PR DESCRIPTION
## Summary

- Adds `__pycache__/` and `*.pyc` to `.gitignore` so the bytecode cache produced by running `scripts/rename-template.py` locally doesn't show up as untracked.

## Test plan

- [x] `git status` no longer reports `scripts/__pycache__/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)