### PR TITLE
fix(scripts): handle diacritics + all plugin slugs in rename-template

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,0 +1,30 @@
+name: Python tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/**'
+      - '.github/workflows/python_tests.yml'
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - '.github/workflows/python_tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.x'
+      - name: Install pytest
+        run: pip install pytest
+      - name: Run tests
+        run: python -m pytest scripts/ -v

--- a/scripts/rename-template.py
+++ b/scripts/rename-template.py
@@ -40,6 +40,7 @@ import os
 import re
 import shutil
 import sys
+import unicodedata
 from pathlib import Path
 
 OLD_PACKAGE = "com.thecompany.consultme"
@@ -67,7 +68,13 @@ def fail(msg: str) -> None:
 
 
 def to_pascal(name: str) -> str:
-    parts = re.findall(r"[A-Za-z0-9]+", name)
+    # NFD-decompose so diacritics split into a base letter plus a combining mark,
+    # then drop the marks. Without this, the [A-Za-z0-9]+ regex below silently
+    # skips non-ASCII letters and produces e.g. "CeGTesc" from "Ce gătesc?"
+    # (Romanian: "What am I cooking?") because "ă" doesn't match the class.
+    decomposed = unicodedata.normalize("NFD", name)
+    ascii_safe = "".join(c for c in decomposed if not unicodedata.combining(c))
+    parts = re.findall(r"[A-Za-z0-9]+", ascii_safe)
     if not parts:
         fail(f"app name '{name}' has no alphanumeric characters")
     return "".join(p[:1].upper() + p[1:] for p in parts)
@@ -139,9 +146,14 @@ def rename_project_files(root: Path, old: str, new: str) -> None:
 
 
 def rename_plugin_files(root: Path, old_slug: str, new_slug: str) -> None:
+    """Rename every precompiled-script plugin under build-logic/ that starts
+    with the template slug. Covers consultme.android.*, consultme.jvm.*,
+    consultme.kover, consultme.modulegraph — all the IDs adopters reference
+    via id("consultme.…") in module build scripts.
+    """
     if old_slug == new_slug:
         return
-    prefix = f"{old_slug}.android."
+    prefix = f"{old_slug}."
     for path in iter_files(root):
         if path.name.startswith(prefix) and path.name.endswith(".gradle.kts"):
             path.rename(path.with_name(path.name.replace(old_slug, new_slug, 1)))
@@ -211,16 +223,18 @@ def main() -> int:
 
     print(f"Package:      {OLD_PACKAGE} -> {new_package}")
     print(f"Project name: {OLD_PROJECT} -> {new_project}")
-    print(f"Plugin slug:  {OLD_PLUGIN_SLUG}.android.* -> {new_plugin_slug}.android.*")
+    print(f"Plugin slug:  {OLD_PLUGIN_SLUG}.* -> {new_plugin_slug}.*")
     print(f"App name:     '{OLD_APP_NAME}' -> '{new_app_name}'")
 
-    # Order matters: the package replacement runs first so that the lowercase
-    # 'consultme' slug replacement that follows only touches plugin IDs, not
-    # the package suffix.
+    # Order matters: the package replacement runs first so the broader slug
+    # replacement that follows only touches plugin IDs, not the package suffix.
+    # The slug replacement covers consultme.android.*, consultme.jvm.*,
+    # consultme.kover, consultme.modulegraph — every precompiled-script plugin
+    # under build-logic/ that adopters reference via id("consultme.…").
     replacements = [
         (OLD_PACKAGE, new_package),
         (OLD_PROJECT, new_project),
-        (f"{OLD_PLUGIN_SLUG}.android.", f"{new_plugin_slug}.android."),
+        (f"{OLD_PLUGIN_SLUG}.", f"{new_plugin_slug}."),
         (OLD_APP_NAME, new_app_name),
     ]
     changed = 0

--- a/scripts/test_rename_template.py
+++ b/scripts/test_rename_template.py
@@ -1,0 +1,65 @@
+# Copyright 2026 MyCompany
+"""Unit tests for rename-template.py.
+
+Run from the repo root:
+    python3 -m pytest scripts/test_rename_template.py -v
+
+The hyphen in rename-template.py means it's not directly importable; the
+fixture below loads it via importlib so the tests stay decoupled from any
+__init__.py / packaging gymnastics.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "rename_template",
+        Path(__file__).parent / "rename-template.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rename_template = _load_module()
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        # Plain ASCII passes through unchanged.
+        ("My App", "MyApp"),
+        ("ConsultMe", "ConsultMe"),
+        # Romanian: the original bug. "ă" decomposes to "a + combining breve",
+        # the combining mark is stripped, the base letter survives.
+        ("Ce gătesc?", "CeGatesc"),
+        # French / English with diacritics.
+        ("Café", "Cafe"),
+        ("Naïve", "Naive"),
+    ],
+)
+def test_to_pascal_handles_diacritics(name, expected):
+    assert rename_template.to_pascal(name) == expected
+
+
+def test_rename_plugin_files_covers_all_consultme_plugins(tmp_path):
+    plugins = [
+        "consultme.android.application.gradle.kts",
+        "consultme.android.compose.gradle.kts",
+        "consultme.jvm.library.gradle.kts",
+        "consultme.kover.gradle.kts",
+        "consultme.modulegraph.gradle.kts",
+    ]
+    for name in plugins:
+        (tmp_path / name).touch()
+
+    rename_template.rename_plugin_files(tmp_path, "consultme", "acme")
+
+    expected = {name.replace("consultme.", "acme.", 1) for name in plugins}
+    actual = {p.name for p in tmp_path.iterdir()}
+    assert actual == expected


### PR DESCRIPTION
## Summary

Fixes two latent bugs in `scripts/rename-template.py` that adopters with non-ASCII app names or non-`.android.` convention plugins would hit.

### Bug 1 — diacritics silently truncate the PascalCase name

`to_pascal()` ran a bare `[A-Za-z0-9]+` regex over the app name, so any character outside the ASCII letter range got dropped. For `app="Ce gătesc?"` (Romanian: "What am I cooking?"), the regex tokenized to `["Ce", "g", "tesc"]` — splitting the word at `ă` — and produced `CeGTesc` instead of `CeGatesc`. The same bug affects Czech / Polish / Vietnamese / French names with diacritics.

**Before**

```
$ rename-template.py com.acme.cegatesc "Ce gătesc?"
Project name: ConsultMe -> CeGTesc
```

**After**

```
$ rename-template.py com.acme.cegatesc "Ce gătesc?"
Project name: ConsultMe -> CeGatesc
```

The fix NFD-normalizes first and strips combining marks, so `ă → a + ̆` → `a`, `é → e`, etc.

### Bug 2 — partial plugin-ID rename

`rename_plugin_files()` and the text-replacement step both gated on the `consultme.android.` prefix. The other slugs — `consultme.jvm.library`, `consultme.kover`, `consultme.modulegraph` — were left untouched. Adopters wound up with a mismatched mix of `acme.android.*` IDs and `consultme.kover` references, and had to clean up by hand.

Now both file rename and text replacement broaden to the full `consultme.` prefix, which after the package replacement only matches plugin IDs (the `com.thecompany.consultme` package path has already been replaced by then).

## Test plan

- [x] `python3 -m pytest scripts/ -v` — 6 new tests pass locally
- [x] New `.github/workflows/python_tests.yml` runs pytest in CI on changes to `scripts/**`
- [x] `bootstrap-from-template.yml` workflow still works — it just shells out to the script and inherits the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)