### PR TITLE
fix(spotless): use plugins-block delimiter so kotlinGradle headers actually rewrite

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,8 +40,12 @@ subprojects {
         }
         kotlinGradle {
             target("*.gradle.kts")
-            // No `package` line in Gradle scripts; place header above the first `/*`.
-            licenseHeader(licenseHeaderText, "/*")
+            // No `package` line in Gradle scripts; place header above `plugins {`,
+            // which every subproject's build.gradle.kts has. Note: the delimiter is
+            // a regex — the previous value of `"/*"` was actually `0-or-more /`, so
+            // it silently matched everywhere and Spotless never rewrote the existing
+            // `// Copyright …` line when adopters changed template.company.
+            licenseHeader(licenseHeaderText, "plugins \\{")
             ktlint(libs.ktlint.get().version)
         }
     }


### PR DESCRIPTION
## Summary

The `kotlinGradle` Spotless target used `"/*"` as the licenseHeader delimiter. Spotless treats the delimiter as a **regex**, and `"/*"` parses as `zero-or-more '/'` — which matches at every position in every file. The result is that Spotless considered the header "already present" and never rewrote the existing `// Copyright … MyCompany` line, even after adopters changed `template.company` in `gradle.properties`.

Net effect for adopters: `.kt` files got their headers rewritten correctly (the `kotlin` target uses `"package "` as its delimiter, which works), but every `.gradle.kts` file kept the old `MyCompany` header forever. The downstream Cookingsaver port hit this and had to bulk-rewrite the headers via `sed` (https://github.com/Tarek-Bohdima/Cookingsaver/pull/6).

## Before / after

Same gradle.properties (`template.company=AcmeCo`), same `./gradlew :feature-example:spotlessApply`:

**Before**
```diff
  // Copyright 2025 MyCompany   (unchanged — Spotless silently skipped it)
  plugins {
      id("consultme.android.feature")
```

**After**
```diff
- // Copyright 2025 MyCompany
+ // Copyright 2025 AcmeCo
  plugins {
      id("consultme.android.feature")
```

## Why `plugins {` works as a delimiter

Every subproject `build.gradle.kts` in the template starts with `// Copyright … MyCompany` followed immediately by `plugins {`. The regex `plugins \{` matches that line; Spotless inserts the (now correct) header before it and removes anything between start-of-file and the delimiter — replacing the stale header with the freshly-rendered one.

## Test plan

- [x] Verified locally: `./gradlew :feature-example:spotlessApply -Ptemplate.company=AcmeCo` rewrites the header (would no-op before this fix).
- [ ] CI `spotlessCheck` passes
- [ ] CI `build_and_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)