### PR TITLE
docs(feature-example): flag the placeholder loudly so it doesn't ship

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,9 @@ android {
 dependencies {
     implementation(projects.coreDesignsystem)
     implementation(projects.coreUi)
+    // TODO(template): replace projects.featureExample with your real feature
+    // module(s) before shipping. The launcher activity in :app currently
+    // renders `ExampleScreen` from this placeholder — see feature-example/README.md.
     implementation(projects.featureExample)
 
     implementation(libs.androidx.core.ktx)

--- a/feature-example/README.md
+++ b/feature-example/README.md
@@ -1,0 +1,29 @@
+# :feature-example
+
+> **Placeholder.** Replace this module with your real feature(s) before shipping.
+
+This module exists to give new adopters a worked example of how a
+`consultme.android.feature`-conventioned screen module is wired:
+
+- One Composable per screen (stateful + stateless overloads)
+- One `ViewModel` exposing a `StateFlow<UiState>`
+- Unit tests in `src/test/`, Compose UI tests in `src/androidTest/`
+- Hilt-injected smoke test under `src/androidTest/` showing the runner+rule wiring
+
+Use it as a reference when you build your first real feature module.
+**Once you have one, delete this module** (and remove the
+`projects.featureExample` line from `app/build.gradle.kts`) — the launcher
+activity in `:app` currently renders `ExampleScreen` from here, so leaving the
+module around means your app ships a placeholder screen.
+
+## How to remove this module
+
+1. Add your replacement feature module (e.g. `:feature-home`) and wire it into
+   `:app` via `implementation(projects.featureHome)`.
+2. Update `MainActivity` to navigate to your new screen instead of `ExampleScreen`.
+3. Delete the `implementation(projects.featureExample)` line in `app/build.gradle.kts`.
+4. Remove `include(":feature-example")` from `settings.gradle.kts`.
+5. `rm -rf feature-example/`.
+
+See `docs/MODULE_GRAPH.md` and the CLAUDE.md "Module graph" section for the
+broader module-graph conventions this template enforces.


### PR DESCRIPTION
## Summary

`:feature-example` is the template's worked example of a `consultme.android.feature` module. Adopters tend to add their real feature modules alongside it, the placeholder lingers, and `:app`'s launcher activity keeps rendering `ExampleScreen` because `implementation(projects.featureExample)` in `app/build.gradle.kts` is still wired. Real-world adoption has surfaced cases where this only gets caught during a manual smoke test after multiple feature modules already shipped.

This PR keeps the module (it's still the only worked example of the conventions for first-time adopters) but adds two loud warnings:

1. A `// TODO(template):` comment on the `projects.featureExample` dep line in `app/build.gradle.kts` — first place anyone reading the app's wiring will see.
2. A `README.md` inside `feature-example/` explaining the role and listing the removal steps when adopters are ready.

## Why not have the bootstrap script delete it?

The friction report proposed deleting `:feature-example` from the bootstrap. Pushed back: adopters use it as scaffolding while they write their first real feature, and being able to *read* the placeholder during a port is concretely useful. Loud warnings let it stay around as a reference but make it impossible to miss when it's time to remove.

## Test plan

- [x] Repo still builds — no logic changes, just comments + a new README
- [x] CI `build_and_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)