### PR TITLE
docs(gitignore): soften google-services.json comment + document the override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,13 @@ output.json
 *.keystore
 .signing/ # If you have a .signing directory for config
 
-# Google Services (Firebase, Google Cloud APIs) - CRITICAL TO IGNORE
+# Google Services (Firebase, Google Cloud APIs)
+# Blanket rule, conservative by default: Firebase client API keys aren't true
+# secrets (security is enforced server-side via Firebase Rules), but the file
+# also pins your project + client IDs and may include SHAs. Public-repo forks
+# should keep this ignored. Private-repo adopters who need flavor-driven client
+# selection at build time can opt back in by uncommenting the exception below:
+#   !app/google-services.json
 google-services.json
 
 # Android Profiling & Debugging


### PR DESCRIPTION
## Summary

The `.gitignore` entry for `google-services.json` was labeled "CRITICAL TO IGNORE", which scares off private-repo adopters who legitimately want to commit the file for flavor-driven Firebase client selection at build time. Firebase client API keys aren't true secrets — security is enforced server-side via Firebase Rules — so the blanket "CRITICAL" framing is misleading.

Real-world adoption hit exactly this: CI couldn't find a `google-services.json` that the adopter `git add`'d but had been silently skipped by the ignore rule.

## Before / after

**Before**
```gitignore
# Google Services (Firebase, Google Cloud APIs) - CRITICAL TO IGNORE
google-services.json
```

**After**
```gitignore
# Google Services (Firebase, Google Cloud APIs)
# Blanket rule, conservative by default: Firebase client API keys aren't true
# secrets (security is enforced server-side via Firebase Rules), but the file
# also pins your project + client IDs and may include SHAs. Public-repo forks
# should keep this ignored. Private-repo adopters who need flavor-driven client
# selection at build time can opt back in by uncommenting the exception below:
#   !app/google-services.json
google-services.json
```

## Test plan

- [x] Pure comment change in `.gitignore` — no code or build behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)