### PR TITLE
feat(build-logic): ship consultme.android.roborazzi convention plugin

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     compileOnly(libs.ksp.gradle.plugin)
     compileOnly(libs.kover.gradle.plugin)
     compileOnly(libs.androidx.baselineprofile.gradle.plugin)
+    compileOnly(libs.roborazzi.gradle.plugin)
 
     // Expose the `libs` version-catalog accessor inside precompiled script plugins.
     // See https://github.com/gradle/gradle/issues/15383

--- a/build-logic/convention/src/main/kotlin/consultme.android.roborazzi.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/consultme.android.roborazzi.gradle.kts
@@ -1,0 +1,44 @@
+// Copyright 2026 MyCompany
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.accessors.dm.LibrariesForLibs
+
+// Roborazzi JVM snapshot-test wiring. Apply to a module that already applies
+// `consultme.android.feature` (or library + compose) and you get:
+//   - the `io.github.takahirom.roborazzi` Gradle plugin (record/verify tasks)
+//   - roborazzi + roborazzi-compose + robolectric on testImplementation
+//   - testOptions.unitTests.isIncludeAndroidResources = true, which is
+//     required for stringResource(R.string.…) to resolve in JVM tests
+//
+// Workflow:
+//   ./gradlew :feature-foo:recordRoborazziDebug   # generate baselines
+//   ./gradlew :feature-foo:verifyRoborazziDebug   # CI gate against baselines
+//
+// AGP 9 compatibility starts at roborazzi 1.56.0 (older releases reference the
+// now-removed TestedExtension). Pinned in gradle/libs.versions.toml.
+
+plugins {
+    id("io.github.takahirom.roborazzi")
+}
+
+val libs = the<LibrariesForLibs>()
+
+// AGP 9 dropped the catch-all `CommonExtension<*, *, *, *, *, *>` generic, so
+// resolve the concrete extension type instead — whichever one the consuming
+// module declared via its other conventions.
+extensions.findByType(LibraryExtension::class.java)?.apply {
+    testOptions.unitTests.isIncludeAndroidResources = true
+}
+extensions.findByType(ApplicationExtension::class.java)?.apply {
+    testOptions.unitTests.isIncludeAndroidResources = true
+}
+
+dependencies {
+    // The Compose BOM aligns the test-side compose deps with main-set versions.
+    "testImplementation"(platform(libs.androidx.compose.bom))
+    // createComposeRule + onRoot — used by every screenshot test.
+    "testImplementation"(libs.androidx.compose.ui.test.junit4)
+    "testImplementation"(libs.roborazzi)
+    "testImplementation"(libs.roborazzi.compose)
+    "testImplementation"(libs.robolectric)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,9 @@ plugins {
     // `consultme.android.application` and `consultme.android.baselineprofile`
     // convention plugins can apply it.
     alias(libs.plugins.androidx.baselineprofile) apply false
+    // Roborazzi plugin on the root classpath so the `consultme.android.roborazzi`
+    // convention plugin can apply it by id without specifying a version.
+    alias(libs.plugins.roborazzi) apply false
     // Kover applied at root aggregates coverage from every module that also
     // applies the consultme.kover convention. `./gradlew koverHtmlReport`
     // produces a project-wide report under `build/reports/kover/`.

--- a/feature-example/build.gradle.kts
+++ b/feature-example/build.gradle.kts
@@ -1,6 +1,7 @@
 // Copyright 2025 MyCompany
 plugins {
     id("consultme.android.feature")
+    id("consultme.android.roborazzi")
 }
 
 android {

--- a/feature-example/src/test/java/com/thecompany/consultme/feature/example/ui/ExampleScreenSnapshotTest.kt
+++ b/feature-example/src/test/java/com/thecompany/consultme/feature/example/ui/ExampleScreenSnapshotTest.kt
@@ -1,0 +1,46 @@
+// Copyright 2026 MyCompany
+package com.thecompany.consultme.feature.example.ui
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Worked example of a Roborazzi snapshot test. Renders [ExampleScreen] on a
+ * Robolectric-backed virtual device, captures a PNG, and (in verify mode)
+ * diffs it against the baseline under
+ * `feature-example/src/test/snapshots/roborazzi/`.
+ *
+ * Workflow when adopting:
+ *   ./gradlew :feature-example:recordRoborazziDebug   # generate baseline
+ *   git add feature-example/src/test/snapshots/       # commit baseline
+ *   ./gradlew :feature-example:verifyRoborazziDebug   # CI gate
+ *
+ * Kept @Ignore in the template because no baseline ships with the
+ * placeholder — removing @Ignore on a clean checkout would make CI fail.
+ * Adopters who keep this module past the first feature port should record
+ * a baseline and remove the annotation.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [34])
+class ExampleScreenSnapshotTest {
+
+    @get:Rule val composeRule = createComposeRule()
+
+    @Test
+    @Ignore("Remove after running ./gradlew :feature-example:recordRoborazziDebug")
+    fun exampleScreen_idle_matchesBaseline() {
+        composeRule.setContent {
+            ExampleScreen(uiState = ExampleUiState.Idle, onClick = {})
+        }
+        composeRule.onRoot().captureRoboImage()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ junit = "4.13.2"
 kotlin = "2.3.21"
 ksp = "2.3.7"
 mockk = "1.14.7" # A recent stable version of MockK
+roborazzi = "1.56.0"   # AGP 9 compatibility starts at 1.56.0 (older 1.x references the removed TestedExtension).
+robolectric = "4.15.1" # Pulled by roborazzi-compose; pinned here so adopters can override.
 turbine = "1.2.1"  # A recent stable version of Turbine
 truth = "1.4.5"    # A recent stable version of Google's Truth
 
@@ -66,6 +68,7 @@ compose-compiler-gradle-plugin = { group = "org.jetbrains.kotlin", name = "compo
 ksp-gradle-plugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 kover-gradle-plugin = { group = "org.jetbrains.kotlinx.kover", name = "org.jetbrains.kotlinx.kover.gradle.plugin", version.ref = "kover" }
 androidx-baselineprofile-gradle-plugin = { group = "androidx.baselineprofile", name = "androidx.baselineprofile.gradle.plugin", version.ref = "androidxBaselineprofile" }
+roborazzi-gradle-plugin = { group = "io.github.takahirom.roborazzi", name = "roborazzi-gradle-plugin", version.ref = "roborazzi" }
 
 javax-inject = { module = "javax.inject:javax.inject", version.ref = "javaxInject" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -86,6 +89,12 @@ turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine
 
 # Truth (for fluent assertions)
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
+
+# Roborazzi (JVM Compose snapshot testing). Brought in via the
+# consultme.android.roborazzi convention plugin.
+roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", version.ref = "roborazzi" }
+roborazzi-compose = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose", version.ref = "roborazzi" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [bundles]
 # Compose UI deps applied via the consultme.android.compose convention plugin.
@@ -124,4 +133,5 @@ hilt-gradle = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 androidx-baselineprofile = { id = "androidx.baselineprofile", version.ref = "androidxBaselineprofile" }
+roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
## Summary

Adds a `consultme.android.roborazzi` convention plugin so adopters who want JVM Compose snapshot testing get the whole setup with one line: `id("consultme.android.roborazzi")`.

Roborazzi has three not-obvious gotchas:
- AGP 9 compatibility starts at Roborazzi **1.56.0** (older 1.x references the removed `TestedExtension`).
- `testOptions.unitTests.isIncludeAndroidResources = true` is required for `stringResource(R.string.…)` to resolve under Robolectric.
- A catalog naming collision is easy to hit if `roborazzi` is added as both a library and a plugin alias.

This convention folds all three concerns into one place.

## What's in the convention

- Applies the `io.github.takahirom.roborazzi` Gradle plugin (registers `recordRoborazziDebug` / `verifyRoborazziDebug` tasks).
- Wires `roborazzi` + `roborazzi-compose` + `robolectric` on `testImplementation`.
- Wires the Compose BOM + `ui-test-junit4` for `createComposeRule` access from JVM tests.
- Enables `testOptions.unitTests.isIncludeAndroidResources` via `LibraryExtension` / `ApplicationExtension`. AGP 9 dropped the catch-all `CommonExtension<*, *, *, *, *, *>` generic, so the convention resolves the concrete extension type instead.

## Catalog additions (`gradle/libs.versions.toml`)

```toml
roborazzi = "1.56.0"     # AGP 9 baseline; older versions reference removed TestedExtension
robolectric = "4.15.1"   # Pulled by roborazzi-compose; pinned so adopters can override
```

## Example test

`:feature-example` applies the convention and ships `ExampleScreenSnapshotTest` as a worked example. The test is `@Ignore`'d because the template doesn't commit a baseline.

## Verified locally

- [x] `./gradlew :feature-example:tasks` — `recordRoborazziDebug` / `verifyRoborazziDebug` show up
- [x] `./gradlew :feature-example:compileDebugUnitTestKotlin` succeeds (test class type-checks)
- [x] `./gradlew spotlessCheck` passes
- [x] CI `build_and_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)