### PR TITLE
ci(codeql): skip analyze on private-repo forks without GHAS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,7 +72,11 @@ jobs:
 
   analyze:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # Skip on private-repo forks: CodeQL requires GitHub Advanced Security on
+    # private repos (paid), and every PR's analyze jobs fail with "Code scanning
+    # is not enabled for this repository" — burning ~3 min per PR per language.
+    # Adopters with GHAS on a private fork can drop the `private == false` half.
+    if: needs.changes.outputs.code == 'true' && github.event.repository.private == false
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

CodeQL Analyze requires GitHub Advanced Security on private repos (a paid feature). On private-repo forks without GHAS — the common adoption shape — every PR's analyze jobs fail with `Code scanning is not enabled for this repository`, burning ~3 min per PR per language for nothing. Real-world adoption has surfaced this enough that some forks just remove the workflow.

This PR gates the `analyze` job on `github.event.repository.private == false`. Public-repo forks (template default) keep CodeQL on every code change; private-repo forks become no-ops automatically. Adopters with GHAS on a private fork can drop the `private == false` half of the condition.

The lightweight `changes` classifier job still runs unconditionally — it's a ~10s `gh api` call with no real cost.

## Before / after

**Before** — private-repo PR check list (3 failing CodeQL jobs):
```
Analyze (actions)        fail   3m12s   Code scanning is not enabled
Analyze (java-kotlin)    fail   3m24s   Code scanning is not enabled
Analyze (python)         fail   3m02s   Code scanning is not enabled
```

**After** — private-repo PR check list: the matrix is skipped, only the `changes` classifier runs (10s, free).

## Test plan

- [x] Workflow YAML still parses (only an `if:` expression added)
- [ ] CI passes on this PR (this repo is public, so the gate evaluates to `true` and analyze runs as today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)