### PR TITLE
docs(core): orient adopters at the empty core-* module roots

### DIFF
--- a/core-common/README.md
+++ b/core-common/README.md
@@ -1,0 +1,43 @@
+# :core-common
+
+Pure-Kotlin shared utilities consumed across the module graph. No
+Android dependencies, no Hilt, no AGP. Built with the
+`consultme.jvm.library` convention.
+
+## What's here today
+
+- `AppDispatchers` — enum of `Main` / `IO` / `Default` dispatchers,
+  the NIA-style qualifier for Hilt-injected coroutine contexts.
+- `Dispatcher` — the matching `@Qualifier` annotation for parameter
+  injection.
+
+Adopters typically inject like:
+
+```kotlin
+class Foo @Inject constructor(
+    @Dispatcher(AppDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+)
+```
+
+The wiring lives in `:app`'s Hilt module (or a per-feature module if
+preferred).
+
+## What else belongs here
+
+- Pure-Kotlin extension functions used by ≥ 2 modules
+- Result wrappers / sealed error hierarchies that are framework-agnostic
+- Time providers, ID generators, encoding helpers
+
+## What does **not** belong here
+
+- Android types (`Context`, `Intent`, anything from `androidx.*`) —
+  those belong in `:core-ui` or a feature module.
+- Room / data-layer types — those live in `:core-data` /
+  `:core-database`.
+- Domain use cases — those live in `:core-domain`.
+
+## Why a separate module
+
+Pure-Kotlin means JVM tests run with no Android shim, and downstream
+modules pay no AGP-config cost when they only need a dispatcher
+qualifier. See `docs/MODULE_GRAPH.md` for the broader module graph.

--- a/core-domain/README.md
+++ b/core-domain/README.md
@@ -1,0 +1,34 @@
+# :core-domain
+
+Pure-Kotlin domain layer — use-case classes that orchestrate repository
+calls and expose a single `operator fun invoke(...)` per use case. No
+Android dependencies, no Hilt, no AGP. Built with the
+`consultme.jvm.library` convention.
+
+## What belongs here
+
+- Use-case classes (`GetUserPreferencesUseCase`, `SyncFridgeUseCase`, …)
+- Domain-level errors and result wrappers, if they're independent of
+  the data layer
+
+## What does **not** belong here
+
+- Composables, view models, or any Android types — those live in
+  `:feature-*` or `:core-ui`.
+- Room entities, DAOs, or DTOs — those stay in `:core-data` /
+  `:core-database`. Map them to plain `:core-model` types at the
+  repository boundary.
+- Coroutine dispatcher injection at construction time — use the
+  `Dispatcher` / `AppDispatchers` qualifiers from `:core-common`
+  instead.
+
+## Why a separate module
+
+Keeping use cases pure-Kotlin means they run in JVM unit tests with no
+Robolectric / AndroidJUnitRunner overhead, and they're trivially
+swappable across `:feature-*` modules without dragging Android types
+through compile classpaths.
+
+The module ships empty; adopters add use-case files alongside this
+README. See `docs/MODULE_GRAPH.md` for how it relates to the rest of
+the module graph.

--- a/core-ui/README.md
+++ b/core-ui/README.md
@@ -1,0 +1,36 @@
+# :core-ui
+
+Shared Compose composables that aren't part of the design system —
+generic UI states like loading, empty, and error containers, custom
+modifiers, reusable list scaffolds. Built with the
+`consultme.android.library` + `consultme.android.compose` conventions.
+
+## What belongs here
+
+- Stateless Composables shared across two or more `:feature-*`
+  modules (`LoadingIndicator`, `EmptyState`, `ErrorBanner`, …)
+- Reusable Compose modifiers and animation helpers
+- Pure-UI utilities that consume the design system but aren't part of
+  it (e.g. screen-level scaffolds that compose `:core-designsystem`
+  tokens with `:feature-*` content slots)
+
+## What does **not** belong here
+
+- Design tokens (colors, typography, theme) — those live in
+  `:core-designsystem`.
+- Feature-specific screens — those live in the owning `:feature-*`
+  module.
+- Anything that requires Hilt injection — `:core-ui` deliberately
+  stays Hilt-free so it can be consumed by every feature without
+  pulling DI graph dependencies.
+
+## Why a separate module
+
+`:core-designsystem` owns the theme; `:core-ui` owns the "glue" that
+every screen needs but that isn't worth re-implementing per feature.
+Keeping these split means design-token changes don't trigger
+recompilation of the glue layer, and vice versa.
+
+The module ships as a scaffold (manifest + lint baseline only).
+Adopters add composables alongside this README; see
+`docs/MODULE_GRAPH.md` for the overall module graph.


### PR DESCRIPTION
## Summary

`:core-domain`, `:core-ui`, and `:core-common` ship as scaffolds or near-scaffolds. Adopters opening the dir tree see empty Kotlin source roots (or a lone Dispatcher qualifier in `:core-common`) and don't know what each module is for without reading `docs/MODULE_GRAPH.md` or `CLAUDE.md`.

One README per module explaining role + what belongs / doesn't belong:

- **`:core-domain`** — pure-Kotlin use cases. No Android, no Hilt. Built with `consultme.jvm.library`.
- **`:core-ui`** — shared Compose glue (loading/empty/error containers, reusable modifiers). Hilt-free by design.
- **`:core-common`** — pure-Kotlin utilities. Today: `Dispatcher` + `AppDispatchers` qualifiers.

Each README also lists what should NOT live in the module so adopters don't drift the architecture.

## Test plan

- [x] Pure docs change, three new files, no code/build behavior affected
- [ ] CI passes (docs-only paths filter should skip gradle gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)