### PR TITLE
fix(scripts): bootstrap deletes upstream IMPROVEMENT_PLAN.md

### DIFF
--- a/scripts/rename-template.py
+++ b/scripts/rename-template.py
@@ -26,6 +26,10 @@ Performs in one pass:
 - One-shot cleanup: removes .github/workflows/bootstrap-from-template.yml
   if it's still around — that workflow is the UI-equivalent of this
   script and is no longer needed once the rename has run.
+- Template-internal roadmap removal: deletes docs/IMPROVEMENT_PLAN.md.
+  The roadmap is the upstream template's own development plan; adopters
+  shouldn't inherit its phase-tracking noise. Gated on the upstream
+  sentinel header so an adopter's own IMPROVEMENT_PLAN.md is untouched.
 
 Scope: rewrites .kt, .kts, .xml, .toml, .properties files only. README,
 CLAUDE.md, LICENSE.md, and docs/ are intentionally skipped — they contain
@@ -198,6 +202,17 @@ def scrub_template_owner_files(root: Path) -> list[str]:
     if bootstrap_workflow.exists():
         bootstrap_workflow.unlink()
         actions.append("deleted .github/workflows/bootstrap-from-template.yml (one-shot helper)")
+
+    # docs/IMPROVEMENT_PLAN.md tracks the upstream template's own development
+    # phases — it's noise for downstream forks. Gate on the upstream sentinel
+    # header so an adopter who later writes their own IMPROVEMENT_PLAN.md isn't
+    # surprised by re-runs.
+    improvement_plan = root / "docs" / "IMPROVEMENT_PLAN.md"
+    if improvement_plan.exists():
+        first_line = improvement_plan.read_text(encoding="utf-8").splitlines()[:1]
+        if first_line == ["# Template improvement plan"]:
+            improvement_plan.unlink()
+            actions.append("deleted docs/IMPROVEMENT_PLAN.md (template-internal roadmap)")
 
     return actions
 

--- a/scripts/test_rename_template.py
+++ b/scripts/test_rename_template.py
@@ -63,3 +63,27 @@ def test_rename_plugin_files_covers_all_consultme_plugins(tmp_path):
     expected = {name.replace("consultme.", "acme.", 1) for name in plugins}
     actual = {p.name for p in tmp_path.iterdir()}
     assert actual == expected
+
+
+def test_scrub_deletes_upstream_improvement_plan(tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    plan = docs / "IMPROVEMENT_PLAN.md"
+    plan.write_text("# Template improvement plan\n\nPhase 0: …\n", encoding="utf-8")
+
+    actions = rename_template.scrub_template_owner_files(tmp_path)
+
+    assert not plan.exists()
+    assert any("IMPROVEMENT_PLAN.md" in a for a in actions)
+
+
+def test_scrub_preserves_adopters_own_improvement_plan(tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    plan = docs / "IMPROVEMENT_PLAN.md"
+    plan.write_text("# Acme product roadmap\n\nQ1: …\n", encoding="utf-8")
+
+    actions = rename_template.scrub_template_owner_files(tmp_path)
+
+    assert plan.exists()
+    assert not any("IMPROVEMENT_PLAN.md" in a for a in actions)


### PR DESCRIPTION
## Summary

`docs/IMPROVEMENT_PLAN.md` tracks the upstream template's own development phases (Phase 0 cleanup, Phase 5 NIA-alignment, etc.). It's template-internal noise for downstream forks — they don't share the upstream phases, and reading it post-rename is confusing because every phase is "already done."

This PR adds the deletion to `scripts/rename-template.py`'s `scrub_template_owner_files` so the bootstrap (UI workflow + local script) handles it automatically — same pattern as the existing `.github/FUNDING.yml` deletion.

## Pushback to the friction inventory

The brief proposed rewriting it into an "empty template" the adopter fills in. Pushback accepted: just delete, same pattern as `.github/FUNDING.yml`. Adopters who want a roadmap doc create one — no need to dictate the structure.

## Why content-gated, not existence-gated

If an adopter later writes their own `docs/IMPROVEMENT_PLAN.md` and re-runs the script (idempotency is a documented goal), we don't want to nuke it. The gate matches the upstream sentinel header `# Template improvement plan` — the adopter's version will use a different title and survive.

## Test plan

- [x] Two new pytests:
  - `test_scrub_deletes_upstream_improvement_plan` — upstream content removed, action logged
  - `test_scrub_preserves_adopters_own_improvement_plan` — different-title file survives, no action logged
- [x] All 8 tests pass locally (`python3 -m pytest scripts/ -v`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)