### PR TITLE
refactor(build-logic): extract configureUnitTests helper to AndroidExtensions

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/thecompany/consultme/buildlogic/AndroidExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/thecompany/consultme/buildlogic/AndroidExtensions.kt
@@ -1,7 +1,9 @@
 // Copyright 2026 MyCompany
 package com.thecompany.consultme.buildlogic
 
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.dsl.ManagedVirtualDevice
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
@@ -56,6 +58,27 @@ internal fun CommonExtension.configureManagedDevices() {
         device = "Pixel 6"
         apiLevel = 30
         systemImageSource = "aosp-atd"
+    }
+}
+
+/**
+ * Toggle `testOptions.unitTests.isIncludeAndroidResources` on whichever Android
+ * extension the consuming module declared (library or application). Required
+ * for `stringResource(R.string.…)` to resolve under JVM-runtime test frameworks
+ * like Robolectric / Roborazzi.
+ *
+ * AGP 9 dropped the catch-all `CommonExtension<*, *, *, *, *, *>` generic shape
+ * (the seventh arg shifted, breaking call sites that hardcoded the cardinality),
+ * so this helper resolves the concrete extension type instead. Whichever applies
+ * to the module gets configured; the other findByType returns null and is
+ * skipped.
+ */
+internal fun Project.configureUnitTests(includeAndroidResources: Boolean = true) {
+    extensions.findByType(LibraryExtension::class.java)?.apply {
+        testOptions.unitTests.isIncludeAndroidResources = includeAndroidResources
+    }
+    extensions.findByType(ApplicationExtension::class.java)?.apply {
+        testOptions.unitTests.isIncludeAndroidResources = includeAndroidResources
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/consultme.android.roborazzi.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/consultme.android.roborazzi.gradle.kts
@@ -1,6 +1,5 @@
 // Copyright 2026 MyCompany
-import com.android.build.api.dsl.ApplicationExtension
-import com.android.build.api.dsl.LibraryExtension
+import com.thecompany.consultme.buildlogic.configureUnitTests
 import org.gradle.accessors.dm.LibrariesForLibs
 
 // Roborazzi JVM snapshot-test wiring. Apply to a module that already applies
@@ -23,15 +22,7 @@ plugins {
 
 val libs = the<LibrariesForLibs>()
 
-// AGP 9 dropped the catch-all `CommonExtension<*, *, *, *, *, *>` generic, so
-// resolve the concrete extension type instead — whichever one the consuming
-// module declared via its other conventions.
-extensions.findByType(LibraryExtension::class.java)?.apply {
-    testOptions.unitTests.isIncludeAndroidResources = true
-}
-extensions.findByType(ApplicationExtension::class.java)?.apply {
-    testOptions.unitTests.isIncludeAndroidResources = true
-}
+configureUnitTests()
 
 dependencies {
     // The Compose BOM aligns the test-side compose deps with main-set versions.


### PR DESCRIPTION
## Summary

The Roborazzi convention plugin (#149) had to hand-roll the AGP 9 `findByType<LibraryExtension>` / `findByType<ApplicationExtension>` dance to flip `testOptions.unitTests.isIncludeAndroidResources`, because the old `CommonExtension<*, *, *, *, *, *>` generic shape was dropped. Any future convention that needs the same toggle (a custom JVM-snapshot library, a Robolectric-driven integration test convention, etc.) would copy-paste the same boilerplate.

This PR promotes the pattern to `AndroidExtensions.kt` as `Project.configureUnitTests(includeAndroidResources: Boolean = true)` and rewrites the Roborazzi convention to use it.

## Before / after

**Before** (`consultme.android.roborazzi.gradle.kts`):
```kotlin
import com.android.build.api.dsl.ApplicationExtension
import com.android.build.api.dsl.LibraryExtension
...
extensions.findByType(LibraryExtension::class.java)?.apply {
    testOptions.unitTests.isIncludeAndroidResources = true
}
extensions.findByType(ApplicationExtension::class.java)?.apply {
    testOptions.unitTests.isIncludeAndroidResources = true
}
```

**After**:
```kotlin
import com.thecompany.consultme.buildlogic.configureUnitTests
...
configureUnitTests()
```

The helper's KDoc documents the AGP 9 generic-shape caveat so the next contributor doesn't trip over it again.

## Test plan

- [x] `./gradlew :feature-example:compileDebugUnitTestKotlin` succeeds locally
- [x] `./gradlew :feature-example:tasks` still lists `recordRoborazziDebug` / `verifyRoborazziDebug`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)