### PR TITLE
docs(baselineprofile): warn loudly about TARGET_PACKAGE + product flavors

### DIFF
--- a/baselineprofile/README.md
+++ b/baselineprofile/README.md
@@ -1,0 +1,50 @@
+# :baselineprofile
+
+`com.android.test` producer module that generates the baseline profile shipped
+with `:app`'s release APK. Built with the `consultme.android.baselineprofile`
+convention.
+
+## What's in here
+
+- `BaselineProfileGenerator` — one-shot collect via `BaselineProfileRule`.
+  Run via `./gradlew :app:generateReleaseBaselineProfile`. The output lands
+  at `app/src/main/baseline-prof.txt` (committed; the runtime side is wired
+  in `:app`'s `consultme.android.application` convention).
+- `StartupBenchmarks` — cold-start macrobenchmark with two compilation modes
+  (`None` for worst-case install, `Partial(BaselineProfileMode.Require)` for
+  installed-with-profile). Run via
+  `./gradlew :baselineprofile:pixel6api30BenchmarkAndroidTest`. The delta
+  between modes is the win adopters get for free from the committed profile.
+
+## TARGET_PACKAGE caveat
+
+Both classes hardcode `TARGET_PACKAGE` to `:app`'s `applicationId`. The
+bootstrap script rewrites this when you rename the template, but it cannot
+know about product flavors. **If `:app` declares product flavors whose
+`applicationId` overrides the `defaultConfig`, you must update
+`TARGET_PACKAGE` by hand to match the flavor you're benchmarking** —
+otherwise `generateReleaseBaselineProfile` fails with `package not found`.
+
+The per-flavor workflow:
+
+1. Pick which flavor you generate the profile from (typically the variant
+   that ships to the largest user base — `pro` over `lite`, `production`
+   over `staging`).
+2. Update `TARGET_PACKAGE` in both files to that flavor's `applicationId`.
+3. Run `./gradlew :app:generate<Flavor>ReleaseBaselineProfile`.
+4. Commit the updated `baseline-prof.txt`.
+
+If you bench multiple flavors regularly, fork the generator into
+flavor-specific copies (one per applicationId) and run them on a schedule
+rather than swapping the constant.
+
+## Why not auto-derive
+
+`com.android.test` modules run macrobenchmark in a process *separate* from
+the app under test, so `InstrumentationRegistry.getInstrumentation().targetContext.packageName`
+doesn't return the benchmarked app's applicationId — it returns the test
+runner's own namespace. Deriving via a `buildConfigField` from `:app`'s
+variant config is technically possible but requires turning on
+`buildFeatures.buildConfig` (which the conventions disable everywhere
+else) and introspecting `:app`'s variant tree from this module's build
+script. Not worth the complexity for what's a once-per-flavor edit.

--- a/baselineprofile/src/main/kotlin/com/thecompany/consultme/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/kotlin/com/thecompany/consultme/baselineprofile/BaselineProfileGenerator.kt
@@ -34,8 +34,12 @@ class BaselineProfileGenerator {
     }
 
     private companion object {
-        // Tracks `:app`'s applicationId. Adopters: keep this in lockstep
-        // when renaming via `scripts/rename-template.py`.
+        // `:app`'s applicationId. The bootstrap script (`scripts/rename-template.py`)
+        // rewrites this when you rename the template's package, but it CANNOT know
+        // about product flavors — if `:app` declares flavors whose applicationId
+        // overrides the defaultConfig, this constant must be updated by hand to
+        // match whichever flavor you're benchmarking, or `generateReleaseBaselineProfile`
+        // fails with "package not found." See `baselineprofile/README.md`.
         const val TARGET_PACKAGE = "com.thecompany.consultme"
     }
 }

--- a/baselineprofile/src/main/kotlin/com/thecompany/consultme/baselineprofile/StartupBenchmarks.kt
+++ b/baselineprofile/src/main/kotlin/com/thecompany/consultme/baselineprofile/StartupBenchmarks.kt
@@ -46,6 +46,11 @@ class StartupBenchmarks {
     }
 
     private companion object {
+        // Must match the applicationId of the `:app` variant being benchmarked.
+        // Adopters who add product flavors must update this per flavor —
+        // macrobenchmark targets a single package, and the defaultConfig value
+        // is never what ships when any flavor sets its own applicationId.
+        // See `baselineprofile/README.md`.
         const val TARGET_PACKAGE = "com.thecompany.consultme"
     }
 }


### PR DESCRIPTION
## Summary

`BaselineProfileGenerator` and `StartupBenchmarks` both hardcode `TARGET_PACKAGE = "com.thecompany.consultme"`. The bootstrap script (`scripts/rename-template.py`) rewrites this on package rename, but it cannot know about product flavors — when adopters declare flavors that override `defaultConfig.applicationId`, the hardcoded constant becomes wrong and `generateReleaseBaselineProfile` fails with `package not found`.

This PR adds three things:

1. Multi-line comment on `TARGET_PACKAGE` in both files explaining the caveat and pointing to the new README.
2. `baselineprofile/README.md` documenting the per-flavor workflow: pick the flavor you want to bench, update the constant, regenerate.
3. The README explains *why* auto-derivation isn't done: macrobenchmark's test process is separate from the app under test, so `InstrumentationRegistry.getInstrumentation().targetContext.packageName` doesn't reach across. `buildConfigField` derivation is technically possible but requires turning on `buildFeatures.buildConfig` (which the conventions disable everywhere else) and introspecting `:app`'s variant tree from this module's build script — disproportionate complexity for what's a once-per-flavor edit.

## Trade-off

The friction inventory's option (a) was "read from a Gradle buildConfigField"; option (b) was "flag this loudly in a comment + README". Going with (b). A buildConfigField approach also doesn't solve the harder case (adopter wants to bench multiple flavors regularly), which the README addresses by suggesting they fork the generator per flavor.

## Test plan

- [x] Pure docs / comment changes; no code-behavior change
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)