### PR TITLE
chore: ignore .pytest_cache from local pytest runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,9 +141,10 @@ hs_err_pid*
 replay_pid*
 
 # === Python ===
-# Bytecode caches from scripts/ helpers
+# Bytecode caches + pytest scratch from scripts/ helpers
 __pycache__/
 *.pyc
+.pytest_cache/
 
 # === AI tooling ===
 # Claude Code local state (settings, scheduled task locks)


### PR DESCRIPTION
## Summary

Running `python3 -m pytest scripts/` (the suite added in #145) creates a `.pytest_cache/` directory at repo root. Same root cause as the `__pycache__` ignore from #144 — cosmetic untracked-files noise after a local test run.

## Test plan

- [x] Pure gitignore addition
- [ ] CI passes (docs/config-only — should skip gradle gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)