### PR TITLE
fix(feature-example): use createComposeRule v2 in snapshot test

### DIFF
--- a/feature-example/src/test/java/com/thecompany/consultme/feature/example/ui/ExampleScreenSnapshotTest.kt
+++ b/feature-example/src/test/java/com/thecompany/consultme/feature/example/ui/ExampleScreenSnapshotTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2026 MyCompany
 package com.thecompany.consultme.feature.example.ui
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.captureRoboImage
 import org.junit.Ignore


### PR DESCRIPTION
## Summary

When the Roborazzi convention landed in #149, `ExampleScreenSnapshotTest` imported the v1 `androidx.compose.ui.test.junit4.createComposeRule`. The Compose UI test library deprecated that overload — v1 uses `UnconfinedTestDispatcher` (executes test coroutines immediately), v2 uses `StandardTestDispatcher` (queues them, aligning with standard coroutine behavior).

Adopters who copy-paste the example would carry the deprecation forward. Migrating now keeps the worked example on the recommended API and silences the warning that was visible during `./gradlew :feature-example:compileDebugUnitTestKotlin`.

## Diff

```diff
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
```

The test itself is unaffected: `@Ignore`'d by default, doesn't exercise coroutine scheduling, just renders a stateless Composable for capture.

## Test plan

- [x] `./gradlew :feature-example:compileDebugUnitTestKotlin --rerun-tasks` succeeds with no deprecation warning
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)