### PR TITLE
polish: add :core-testing README + MD3 Shapes token file

### DIFF
--- a/core-designsystem/src/main/java/com/thecompany/consultme/core/designsystem/theme/Shape.kt
+++ b/core-designsystem/src/main/java/com/thecompany/consultme/core/designsystem/theme/Shape.kt
@@ -1,0 +1,20 @@
+// Copyright 2026 MyCompany
+package com.thecompany.consultme.core.designsystem.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+// Shape tokens consumed by ConsultMeTheme. Values mirror the Material 3
+// defaults so behavior is unchanged out of the box; this file exists so
+// adopters customizing component corners have a single place to edit
+// (and so MaterialTheme.shapes is wired explicitly rather than falling
+// back silently). See Google's `jetpack-compose/theming/styles` Claude
+// Code skill when extending these tokens.
+val Shapes = Shapes(
+    extraSmall = RoundedCornerShape(4.dp),
+    small = RoundedCornerShape(8.dp),
+    medium = RoundedCornerShape(12.dp),
+    large = RoundedCornerShape(16.dp),
+    extraLarge = RoundedCornerShape(28.dp),
+)

--- a/core-designsystem/src/main/java/com/thecompany/consultme/core/designsystem/theme/Theme.kt
+++ b/core-designsystem/src/main/java/com/thecompany/consultme/core/designsystem/theme/Theme.kt
@@ -44,6 +44,7 @@ fun ConsultMeTheme(
     MaterialTheme(
         colorScheme = colorScheme,
         typography = Typography,
+        shapes = Shapes,
         content = content,
     )
 }

--- a/core-testing/README.md
+++ b/core-testing/README.md
@@ -1,0 +1,60 @@
+# :core-testing
+
+Test fixtures shared across every module. Re-exports the standard
+testing toolbox (JUnit + Truth + Turbine + MockK + Hilt-testing +
+coroutines-test + Espresso) and ships the `HiltTestRunner` that every
+module uses as its `testInstrumentationRunner`. Built with the
+`consultme.android.library` convention.
+
+## What belongs here
+
+- Test infrastructure shared by two or more modules: rules, runners,
+  custom matchers, fake/stub builders that aren't feature-specific.
+- The current set:
+  - **`HiltTestRunner`** — `AndroidJUnitRunner` subclass that swaps in
+    `HiltTestApplication`. Wired automatically via every Android
+    convention (`testInstrumentationRunner = "...HiltTestRunner"`).
+  - **`HiltTestRule`** — composed rule pairing `HiltAndroidRule` with
+    `MainDispatcherRule` so a `@HiltAndroidTest` only needs one
+    `@get:Rule`.
+  - **`MainDispatcherRule`** — swaps `Dispatchers.Main` for a
+    `TestDispatcher` for the duration of the test. Use whenever code
+    under test dispatches to `Dispatchers.Main` (typically ViewModels
+    backed by `viewModelScope`).
+
+## What does **not** belong here
+
+- Feature-specific fakes — those live next to the feature they fake
+  (`:feature-example/src/test/...`).
+- Production-side test scaffolding (DI test modules, fake repositories
+  exposed at build time) — those live in the owning module's
+  `src/testFixtures/` or `src/debug/` source set.
+
+## How modules consume it
+
+Modules pull in the bundle via the conventions' standard
+`testImplementation` + `androidTestImplementation` wiring — **do not**
+add JUnit / Espresso / MockK directly in module build scripts.
+
+```kotlin
+dependencies {
+    testImplementation(project(":core-testing"))
+    androidTestImplementation(project(":core-testing"))
+}
+```
+
+The re-export uses Gradle `api(...)` (see `core-testing/build.gradle.kts`),
+backed by the `test-shared` bundle in `gradle/libs.versions.toml`. New
+shared testing libs go into that bundle, not into per-module build
+scripts.
+
+## Why a separate module
+
+A single owning module for the testing toolbox means version bumps
+(JUnit, Truth, MockK, …) happen in one place, and adopters renaming
+the template don't have to chase per-module test deps. Google's
+`testing/testing-setup` Claude Code skill is the companion playbook
+when extending the pattern.
+
+See `docs/MODULE_GRAPH.md` for how it relates to the rest of the
+module graph.


### PR DESCRIPTION
## Summary

Two small companion artifacts for the new adopter-facing skills listed in CLAUDE.md:

- **`core-testing/README.md`** — fills the gap noted by the audit (every other module shipping scaffolding got an orientation README in #151; this one was missed). Documents the `api(...)` re-export pattern, the `test-shared` bundle, and the three test helpers.
- **`Shape.kt` + `Theme.kt` wiring** — Material 3 has three token surfaces (color, typography, shape); the template shipped two. Values mirror MD3 defaults so behavior is unchanged, but adopters customizing component corners now have a single place to edit. `MaterialTheme.shapes` is now wired explicitly rather than falling back silently.

No behavior change.

## Test plan

- [x] `./gradlew spotlessCheck` — green
- [x] `./gradlew :core-designsystem:lintRelease` — green
- [x] `./gradlew test` — green (full unit-test suite, 250 actionable tasks)
- [x] CI will exercise `build_and_test` + `instrumented_tests` (Kotlin source touched)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)