### PR TITLE
docs(README): add logging-guidance section (no module)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,30 @@ Each flavor's `applicationId` is what the Play Store sees and what Firebase / FC
 
 If you wire flavors after generating a baseline profile, also update the `TARGET_PACKAGE` reference in `:baselineprofile` — the macrobenchmark targets a specific applicationId, and the default-flavor value won't match.
 
+## Logging
+
+The template ships **no logging library** — picking one is a cross-cutting decision (alongside networking, analytics, image-loading) that downstream forks tend to make on their own terms. This section is a pointer, not a default.
+
+The conventional baseline for an app of this shape is [Timber](https://github.com/JakeWharton/timber):
+
+```kotlin
+// app/build.gradle.kts (you add this; the template does not)
+dependencies {
+    implementation("com.jakewharton.timber:timber:5.0.1")
+}
+
+// ConsultMeApplication.kt
+override fun onCreate() {
+    super.onCreate()
+    if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
+    // else Timber.plant(CrashlyticsTree())  // see below
+}
+```
+
+For release builds, the standard pattern is a custom `Timber.Tree` that forwards to your crash reporter — most commonly `CrashlyticsTree` forwarding to `FirebaseCrashlytics.recordException(...)`. Keep the `DebugTree` debug-only so noisy logs don't ship to production.
+
+If you'd rather use platform `android.util.Log` directly, SLF4J + Logback, or roll a thin `Logger` interface that adopts a different vendor later, that's fully supported — the template doesn't wire anything that would conflict.
+
 ## How to write a Hilt-aware test
 
 Every module declares `:core-testing` for both unit and instrumented tests, so JUnit/Turbine/MockK/Hilt-testing/Espresso are already on the classpath:


### PR DESCRIPTION
## Summary

Add a short \"Logging\" section between \"Adding product flavors\" and \"How to write a Hilt-aware test\" recommending Timber + DebugTree as the conventional baseline and sketching the CrashlyticsTree pattern for release builds.

The template intentionally ships no logging library — that's a cross-cutting decision adopters tend to make on their own terms. A README pointer gets them unstuck without committing the template to Timber (or anything else).

## Test plan

- [x] Docs-only — CI will skip gradle gates via paths filter
- [x] Reads naturally inline with the rest of the README adopter-customization sections

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)