### PR TITLE
docs: add adaptive-layout adopter guidance + jetpack-compose/adaptive skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Google's official Android Claude Code skills live at <https://github.com/android
 - `jetpack-compose/theming/styles` — extend `:core-designsystem` (icon registries, typography tokens, component variants).
 - `jetpack-compose/migration/migrate-xml-views-to-jetpack-compose` — for adopters porting a legacy Views codebase onto the Compose template.
 - `navigation/navigation-3` — once the template grows a real nav graph beyond the `:feature-example` placeholder.
+- `jetpack-compose/adaptive` — supporting large screens / foldables (`WindowSizeClass`, list-detail / supporting-pane scaffolds). See README "How to support adaptive layouts."
 - `profilers/perfetto-sql`, `profilers/perfetto-trace-analysis` — companions to `:baselineprofile` when investigating startup regressions.
 
 Skills are not vendored — install locally when starting the matching work. See `docs/IMPROVEMENT_PLAN.md` for phase-skill mappings.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,19 @@ Each module ships its own `lint-baseline.xml`. Regenerate after adding code that
 
 Replace `:feature-example` with the module you're updating. CI runs `lintRelease` and fails on any non-baselined violation.
 
+## How to support adaptive layouts (large screens & foldables)
+
+The template already draws **edge-to-edge** — `MainActivity` calls `enableEdgeToEdge()` and the root `Scaffold` consumes window insets — so content lays out correctly behind the system bars on every device.
+
+What the template intentionally does **not** ship is large-screen *layout adaptation*, because `:feature-example` is a throwaway placeholder. When you build your real feature, add the adaptive dependencies to `gradle/libs.versions.toml` (they're left out to keep the template's dependency graph lean):
+
+- `androidx.compose.material3:material3-window-size-class` — read the `WindowSizeClass` to branch between compact/medium/expanded layouts.
+- `androidx.compose.material3.adaptive:adaptive-layout` and `:adaptive-navigation` — list-detail and supporting-pane scaffolds that fold/unfold with available width.
+
+Where things live: put **shared** adaptive containers in `:core-ui` (it's Hilt-free and already the home for reusable UI scaffolds); keep pane/selection logic in the feature module. Full adaptive **navigation** (`NavigationSuiteScaffold`, `SceneStrategy`) pairs with the Navigation 3 work that's still on the roadmap — see the [`navigation/navigation-3`](https://github.com/android/skills) skill for that.
+
+The official [`jetpack-compose/adaptive`](https://github.com/android/skills) Claude Code skill is a step-by-step playbook for the above.
+
 ## Code Quality
 
 - **Spotless + ktlint**: Consistent formatting and license-header enforcement on every `.kt` / `.gradle.kts` file.

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -276,6 +276,7 @@ Google maintains official AI-optimized skills for Android at <https://github.com
 | [`jetpack-compose/theming/styles`](https://github.com/android/skills) | Extending `:core-designsystem` (icons, typography, components) |
 | [`jetpack-compose/migration/migrate-xml-views-to-jetpack-compose`](https://github.com/android/skills) | Porting a legacy Views codebase onto the Compose template |
 | [`navigation/navigation-3`](https://github.com/android/skills) | Growing a real nav graph beyond `:feature-example` |
+| [`jetpack-compose/adaptive`](https://github.com/android/skills) | Supporting large screens / foldables (see README "How to support adaptive layouts") |
 | [`profilers/perfetto-sql`](https://github.com/android/skills), [`profilers/perfetto-trace-analysis`](https://github.com/android/skills) | Investigating startup regressions alongside `:baselineprofile` |
 
 Skills are not vendored into the template — they're maintained upstream by Google. Install them locally when starting the matching work. Keep this list in sync with `CLAUDE.md`'s "Recommended Claude Code skills" section.


### PR DESCRIPTION
Adopter-facing guidance for large screens / foldables. Docs-only — no dependencies or sample code added (the template stays lean and `:feature-example` is a placeholder).

- New README **"How to support adaptive layouts (large screens & foldables)"** section: insets are already handled (edge-to-edge); points at `WindowSizeClass` + `material3-adaptive` coordinates to add when building a real feature; names `:core-ui` as the home for shared adaptive containers; ties full adaptive navigation to the deferred nav-3 work.
- Adds the `jetpack-compose/adaptive` skill to `CLAUDE.md`'s adopter-facing list and the `IMPROVEMENT_PLAN.md` adopter-facing skills table (kept in sync).

Closes #204