### PR TITLE
feat: migrate :app navigation to Navigation 3 + list→detail flow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -118,21 +118,38 @@ Why both:
 
 ## Navigation
 
-Navigation is owned by `:app` — it's the only module that knows about every feature. Each feature exposes a public composable entry point and a route:
+The template uses **[Navigation 3](https://developer.android.com/guide/navigation/navigation-3)** — the app owns the back stack as a plain observable list of type-safe `NavKey`s. Navigation is owned by `:app`: it's the only module that knows about every feature, so it holds the back stack and composes each feature's destinations into a single `NavDisplay`.
+
+Each feature exposes **`@Serializable` `NavKey` route types** and public screen composables; `:app` maps keys to screens:
 
 ```kotlin
-// :feature-example
-@Composable fun ExampleScreen(...)
-fun NavGraphBuilder.exampleScreen() { composable<ExampleRoute> { ExampleScreen() } }
+// :feature-example  (route keys — arguments are constructor properties)
+@Serializable data object ExampleListRoute : NavKey
+@Serializable data class ExampleDetailRoute(val id: Long) : NavKey
 
-// :app
-NavHost(...) {
-    exampleScreen()
-    // otherFeatureScreen()
-}
+// :app  (owns the back stack; one NavDisplay for the whole app)
+val backStack = rememberNavBackStack(ExampleListRoute)
+NavDisplay(
+    backStack = backStack,
+    onBack = { backStack.removeLastOrNull() },
+    entryDecorators = listOf(
+        rememberSaveableStateHolderNavEntryDecorator(),
+        rememberViewModelStoreNavEntryDecorator(), // per-entry ViewModelStore for hiltViewModel()
+    ),
+    entryProvider = entryProvider {
+        entry<ExampleListRoute> {
+            ExampleScreen(onItemClick = { backStack.add(ExampleDetailRoute(it.id)) })
+        }
+        entry<ExampleDetailRoute> { key ->
+            ExampleDetailScreen(itemId = key.id, onBack = { backStack.removeLastOrNull() })
+        }
+    },
+)
 ```
 
-Adopters add destinations the same way. **Never reach into a feature's internal composables** from `:app` or another feature — go through the public route extension.
+Navigate by mutating the back stack (`backStack.add(key)` / `removeLastOrNull()`). Add destinations by adding a route `NavKey` in the feature and an `entry<…>` block in `:app`. **Never reach into a feature's internal composables** — go through the feature's public screen entry point.
+
+**Passing arguments to a ViewModel**: `ExampleDetailViewModel` uses Hilt assisted injection to receive the route id — the `entry<ExampleDetailRoute>` block obtains it via `hiltViewModel<VM, VM.Factory>(creationCallback = { it.create(key.id) })`. The `rememberViewModelStoreNavEntryDecorator()` scopes each entry's ViewModel to that back-stack entry (cleared when it's popped).
 
 ## Why pure-Kotlin domain layers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Google's official Android Claude Code skills live at <https://github.com/android
 - `testing/testing-setup` — companion to `:core-testing`; helps wire JUnit / Espresso / Hilt-test scaffolding into a new feature module.
 - `jetpack-compose/theming/styles` — extend `:core-designsystem` (icon registries, typography tokens, component variants).
 - `jetpack-compose/migration/migrate-xml-views-to-jetpack-compose` — for adopters porting a legacy Views codebase onto the Compose template.
-- `navigation/navigation-3` — once the template grows a real nav graph beyond the `:feature-example` placeholder.
+- `navigation/navigation-3` — the template ships a Navigation 3 graph in `:app` (`NavDisplay` + `@Serializable` `NavKey` routes owned by features; list→detail with an assisted-inject ViewModel). Use the skill when extending it with more destinations or adaptive `NavigationSuiteScaffold` / `SceneStrategy`.
 - `jetpack-compose/adaptive` — supporting large screens / foldables (`WindowSizeClass`, list-detail / supporting-pane scaffolds). See README "How to support adaptive layouts."
 - `profilers/perfetto-sql`, `profilers/perfetto-trace-analysis` — companions to `:baselineprofile` when investigating startup regressions.
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ What the template intentionally does **not** ship is large-screen *layout adapta
 - `androidx.compose.material3:material3-window-size-class` — read the `WindowSizeClass` to branch between compact/medium/expanded layouts.
 - `androidx.compose.material3.adaptive:adaptive-layout` and `:adaptive-navigation` — list-detail and supporting-pane scaffolds that fold/unfold with available width.
 
-Where things live: put **shared** adaptive containers in `:core-ui` (it's Hilt-free and already the home for reusable UI scaffolds); keep pane/selection logic in the feature module. Full adaptive **navigation** (`NavigationSuiteScaffold`, `SceneStrategy`) pairs with the Navigation 3 work that's still on the roadmap — see the [`navigation/navigation-3`](https://github.com/android/skills) skill for that.
+Where things live: put **shared** adaptive containers in `:core-ui` (it's Hilt-free and already the home for reusable UI scaffolds); keep pane/selection logic in the feature module. Full adaptive **navigation** (`NavigationSuiteScaffold`, `SceneStrategy`) builds on the Navigation 3 graph the template already ships in `:app` — see the [`navigation/navigation-3`](https://github.com/android/skills) skill for extending it.
 
 The official [`jetpack-compose/adaptive`](https://github.com/android/skills) Claude Code skill is a step-by-step playbook for the above.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,10 @@ dependencies {
 
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.navigation.compose)
+    // Navigation 3 — app owns the back stack. See ARCHITECTURE.md "Navigation".
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
     implementation(libs.androidx.hilt.navigation.compose)
 
     // Runtime side of the baseline-profile pipeline. Without this dep, the

--- a/app/src/main/java/com/thecompany/consultme/MainActivity.kt
+++ b/app/src/main/java/com/thecompany/consultme/MainActivity.kt
@@ -11,7 +11,16 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
 import com.thecompany.consultme.core.designsystem.theme.ConsultMeTheme
+import com.thecompany.consultme.feature.example.navigation.ExampleDetailRoute
+import com.thecompany.consultme.feature.example.navigation.ExampleListRoute
+import com.thecompany.consultme.feature.example.ui.ExampleDetailScreen
 import com.thecompany.consultme.feature.example.ui.ExampleScreen
 import com.thecompany.consultme.feature.example.ui.ExampleUiState
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,11 +32,39 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             ConsultMeTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    ExampleScreen(modifier = Modifier.padding(innerPadding))
-                }
+                ConsultMeNavDisplay()
             }
         }
+    }
+}
+
+/**
+ * The app-owned Navigation 3 host. `:app` is the only module that knows about
+ * every feature, so it holds the back stack and composes each feature's route
+ * entries into a single [NavDisplay]. Features contribute their `NavKey`s and
+ * screen composables; add new destinations by adding `entry<…>` blocks.
+ */
+@Composable
+private fun ConsultMeNavDisplay() {
+    val backStack = rememberNavBackStack(ExampleListRoute)
+    Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+        NavDisplay(
+            backStack = backStack,
+            modifier = Modifier.padding(innerPadding),
+            onBack = { backStack.removeLastOrNull() },
+            entryDecorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator(),
+                rememberViewModelStoreNavEntryDecorator(),
+            ),
+            entryProvider = entryProvider {
+                entry<ExampleListRoute> {
+                    ExampleScreen(onItemClick = { item -> backStack.add(ExampleDetailRoute(item.id)) })
+                }
+                entry<ExampleDetailRoute> { key ->
+                    ExampleDetailScreen(itemId = key.id, onBack = { backStack.removeLastOrNull() })
+                }
+            },
+        )
     }
 }
 

--- a/core-data/src/main/kotlin/com/thecompany/consultme/core/data/DefaultExampleRepository.kt
+++ b/core-data/src/main/kotlin/com/thecompany/consultme/core/data/DefaultExampleRepository.kt
@@ -19,4 +19,7 @@ class DefaultExampleRepository @Inject constructor(private val exampleItemDao: E
     override fun getExampleItems(): Flow<List<ExampleItem>> = exampleItemDao.getExampleItems().map { entities ->
         entities.map(ExampleItemEntity::asExternalModel)
     }
+
+    override fun getExampleItem(id: Long): Flow<ExampleItem?> =
+        exampleItemDao.getExampleItem(id).map { entity -> entity?.asExternalModel() }
 }

--- a/core-data/src/test/java/com/thecompany/consultme/core/data/DefaultExampleRepositoryTest.kt
+++ b/core-data/src/test/java/com/thecompany/consultme/core/data/DefaultExampleRepositoryTest.kt
@@ -38,5 +38,6 @@ class DefaultExampleRepositoryTest {
 
 private class FakeExampleItemDao(private val items: List<ExampleItemEntity>) : ExampleItemDao {
     override fun getExampleItems(): Flow<List<ExampleItemEntity>> = flowOf(items)
+    override fun getExampleItem(id: Long): Flow<ExampleItemEntity?> = flowOf(items.firstOrNull { it.id == id })
     override suspend fun insertAll(items: List<ExampleItemEntity>) = Unit
 }

--- a/core-database/src/main/kotlin/com/thecompany/consultme/core/database/ExampleItemDao.kt
+++ b/core-database/src/main/kotlin/com/thecompany/consultme/core/database/ExampleItemDao.kt
@@ -17,6 +17,10 @@ interface ExampleItemDao {
     @Query("SELECT * FROM example_items ORDER BY id")
     fun getExampleItems(): Flow<List<ExampleItemEntity>>
 
+    /** Observes a single item by id, emitting `null` if it no longer exists. */
+    @Query("SELECT * FROM example_items WHERE id = :id")
+    fun getExampleItem(id: Long): Flow<ExampleItemEntity?>
+
     @Insert
     suspend fun insertAll(items: List<ExampleItemEntity>)
 }

--- a/core-domain/src/main/kotlin/com/thecompany/consultme/core/domain/ExampleRepository.kt
+++ b/core-domain/src/main/kotlin/com/thecompany/consultme/core/domain/ExampleRepository.kt
@@ -17,4 +17,7 @@ import kotlinx.coroutines.flow.Flow
 interface ExampleRepository {
     /** A stream of the example items, emitting a new list whenever they change. */
     fun getExampleItems(): Flow<List<ExampleItem>>
+
+    /** A stream of a single item by id, emitting `null` if it doesn't exist. */
+    fun getExampleItem(id: Long): Flow<ExampleItem?>
 }

--- a/core-domain/src/main/kotlin/com/thecompany/consultme/core/domain/GetExampleItemUseCase.kt
+++ b/core-domain/src/main/kotlin/com/thecompany/consultme/core/domain/GetExampleItemUseCase.kt
@@ -1,0 +1,14 @@
+// Copyright 2026 MyCompany
+package com.thecompany.consultme.core.domain
+
+import com.thecompany.consultme.core.model.ExampleItem
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Returns a stream of a single example item by id (`null` if it doesn't exist).
+ * Used by the detail screen to load the item the user navigated to.
+ */
+class GetExampleItemUseCase @Inject constructor(private val repository: ExampleRepository) {
+    operator fun invoke(id: Long): Flow<ExampleItem?> = repository.getExampleItem(id)
+}

--- a/feature-example/build.gradle.kts
+++ b/feature-example/build.gradle.kts
@@ -2,6 +2,8 @@
 plugins {
     id("consultme.android.feature")
     id("consultme.android.roborazzi")
+    // NavKey route types are @Serializable so Nav3 can save/restore the back stack.
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -17,4 +19,7 @@ dependencies {
     api(projects.coreDomain)
 
     implementation(libs.androidx.core.ktx)
+    // Route keys implement NavKey; `api` so :app can reference them as NavKey.
+    api(libs.androidx.navigation3.runtime)
+    implementation(libs.kotlinx.serialization.core)
 }

--- a/feature-example/src/androidTest/java/com/thecompany/consultme/feature/example/FakeDataModule.kt
+++ b/feature-example/src/androidTest/java/com/thecompany/consultme/feature/example/FakeDataModule.kt
@@ -28,5 +28,6 @@ object FakeDataModule {
     @Singleton
     fun provideExampleRepository(): ExampleRepository = object : ExampleRepository {
         override fun getExampleItems(): Flow<List<ExampleItem>> = flowOf(emptyList())
+        override fun getExampleItem(id: Long): Flow<ExampleItem?> = flowOf(null)
     }
 }

--- a/feature-example/src/androidTest/java/com/thecompany/consultme/feature/example/ui/ExampleScreenStatefulTest.kt
+++ b/feature-example/src/androidTest/java/com/thecompany/consultme/feature/example/ui/ExampleScreenStatefulTest.kt
@@ -52,4 +52,5 @@ class ExampleScreenStatefulTest {
 
 private class FakeExampleRepository(private val items: List<ExampleItem>) : ExampleRepository {
     override fun getExampleItems(): Flow<List<ExampleItem>> = flowOf(items)
+    override fun getExampleItem(id: Long): Flow<ExampleItem?> = flowOf(items.firstOrNull { it.id == id })
 }

--- a/feature-example/src/main/java/com/thecompany/consultme/feature/example/navigation/ExampleRoutes.kt
+++ b/feature-example/src/main/java/com/thecompany/consultme/feature/example/navigation/ExampleRoutes.kt
@@ -1,0 +1,19 @@
+// Copyright 2026 MyCompany
+package com.thecompany.consultme.feature.example.navigation
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+/**
+ * Navigation 3 route keys for this feature.
+ *
+ * Each key is a `@Serializable` [NavKey] so Nav3 can persist and restore the
+ * back stack across configuration changes and process death. Features own their
+ * route types; `:app` composes them into a single `NavDisplay`. Arguments travel
+ * as constructor properties of the key (e.g. [ExampleDetailRoute.id]).
+ */
+@Serializable
+data object ExampleListRoute : NavKey
+
+@Serializable
+data class ExampleDetailRoute(val id: Long) : NavKey

--- a/feature-example/src/main/java/com/thecompany/consultme/feature/example/ui/ExampleDetailScreen.kt
+++ b/feature-example/src/main/java/com/thecompany/consultme/feature/example/ui/ExampleDetailScreen.kt
@@ -1,0 +1,63 @@
+// Copyright 2026 MyCompany
+package com.thecompany.consultme.feature.example.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.thecompany.consultme.core.model.ExampleItem
+
+/**
+ * Stateful detail entry point. Obtains the [ExampleDetailViewModel] via Hilt's
+ * assisted-factory overload, passing the navigated-to `itemId` through
+ * `creationCallback` — the Nav3 recipe for feeding a route argument into a
+ * ViewModel. `:app` calls this from the `ExampleDetailRoute` entry.
+ */
+@Composable
+fun ExampleDetailScreen(itemId: Long, onBack: () -> Unit, modifier: Modifier = Modifier) {
+    val viewModel = hiltViewModel<ExampleDetailViewModel, ExampleDetailViewModel.Factory>(
+        creationCallback = { factory -> factory.create(itemId) },
+    )
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    ExampleDetailScreen(uiState = uiState, onBack = onBack, modifier = modifier)
+}
+
+/** Stateless overload — used by previews and Compose UI tests. */
+@Composable
+fun ExampleDetailScreen(uiState: ExampleDetailUiState, onBack: () -> Unit, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = when (uiState) {
+                ExampleDetailUiState.Loading -> "Loading…"
+                ExampleDetailUiState.NotFound -> "Item not found."
+                is ExampleDetailUiState.Loaded -> uiState.item.label
+            },
+        )
+        Button(onClick = onBack) { Text(text = "Back") }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExampleDetailLoadedPreview() {
+    ExampleDetailScreen(
+        uiState = ExampleDetailUiState.Loaded(ExampleItem(1, "First example item")),
+        onBack = {},
+    )
+}

--- a/feature-example/src/main/java/com/thecompany/consultme/feature/example/ui/ExampleDetailViewModel.kt
+++ b/feature-example/src/main/java/com/thecompany/consultme/feature/example/ui/ExampleDetailViewModel.kt
@@ -1,0 +1,57 @@
+// Copyright 2026 MyCompany
+package com.thecompany.consultme.feature.example.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.thecompany.consultme.core.domain.GetExampleItemUseCase
+import com.thecompany.consultme.core.model.ExampleItem
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * Detail ViewModel for a single example item.
+ *
+ * Demonstrates the idiomatic Nav3 + Hilt recipe for passing a navigation
+ * argument to a ViewModel: the route id is **assisted-injected** (`@Assisted`)
+ * and the rest of the graph (`GetExampleItemUseCase`) comes from Hilt. The
+ * caller supplies the id through [Factory] via `hiltViewModel(creationCallback)`.
+ */
+@HiltViewModel(assistedFactory = ExampleDetailViewModel.Factory::class)
+class ExampleDetailViewModel @AssistedInject constructor(
+    @Assisted private val itemId: Long,
+    getExampleItem: GetExampleItemUseCase,
+) : ViewModel() {
+
+    val uiState: StateFlow<ExampleDetailUiState> =
+        getExampleItem(itemId)
+            .map { item ->
+                if (item == null) ExampleDetailUiState.NotFound else ExampleDetailUiState.Loaded(item)
+            }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+                initialValue = ExampleDetailUiState.Loading,
+            )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(itemId: Long): ExampleDetailViewModel
+    }
+
+    private companion object {
+        const val STOP_TIMEOUT_MILLIS = 5_000L
+    }
+}
+
+/** UI state for the example detail screen. */
+sealed interface ExampleDetailUiState {
+    data object Loading : ExampleDetailUiState
+    data object NotFound : ExampleDetailUiState
+    data class Loaded(val item: ExampleItem) : ExampleDetailUiState
+}

--- a/feature-example/src/test/java/com/thecompany/consultme/feature/example/ui/ExampleViewModelTest.kt
+++ b/feature-example/src/test/java/com/thecompany/consultme/feature/example/ui/ExampleViewModelTest.kt
@@ -57,4 +57,5 @@ class ExampleViewModelTest {
 
 private class FakeExampleRepository(private val items: List<ExampleItem>) : ExampleRepository {
     override fun getExampleItems(): Flow<List<ExampleItem>> = flowOf(items)
+    override fun getExampleItem(id: Long): Flow<ExampleItem?> = flowOf(items.firstOrNull { it.id == id })
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ androidxComposeBom = "2026.06.01"
 androidxCore = "1.19.0"
 androidxHilt = "1.4.0"
 androidxLifecycle = "2.11.0"
-androidxNavigation = "2.9.8"
+navigation3 = "1.1.4"
 androidxProfileinstaller = "1.4.1"
 androidxRoom = "2.8.4"
 androidxTestCore = "1.7.0"
@@ -23,6 +23,7 @@ spotless = "8.8.0"
 hilt = "2.60.1"
 junit = "4.13.2"
 kotlin = "2.3.21"
+kotlinxSerialization = "1.9.0"
 ksp = "2.3.9"
 mockk = "1.14.11" # A recent stable version of MockK
 roborazzi = "1.69.0"   # AGP 9 compatibility starts at 1.56.0 (older 1.x references the removed TestedExtension).
@@ -43,7 +44,10 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidxLifecycle" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidxRoom" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidxRoom" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidxRoom" }
@@ -129,6 +133,7 @@ android-application = { id = "com.android.application", version.ref = "androidGr
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 hilt-gradle = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
Closes #228.

`:app` declared `androidx.navigation:navigation-compose` (Nav2) but **never used it** — `MainActivity` rendered `ExampleScreen` directly. This introduces **Navigation 3** (stable **1.1.4**) as the nav solution, drops the dead Nav2 dep, and adds a real **list → detail** flow so navigation is actually demonstrated (using the `onItemClick` hook from #226).

## What changed
- **Catalog**: `androidx.navigation3:navigation3-runtime`/`-ui` `1.1.4`, `androidx.lifecycle:lifecycle-viewmodel-navigation3` (Lifecycle line, `2.11.0`), `org.jetbrains.kotlin.plugin.serialization` + `kotlinx-serialization-core`. Removed `androidx-navigation-compose`.
- **`:feature-example`** (features own their destinations): `@Serializable` `ExampleListRoute` / `ExampleDetailRoute(id)` `NavKey`s; `ExampleDetailScreen` + `ExampleDetailViewModel`. The detail VM uses **Hilt assisted injection** to receive the route id — the idiomatic Nav3+Hilt argument-passing recipe.
- **domain/data**: `getExampleItem(id): Flow<ExampleItem?>` added to the DAO, repository port + adapter, and a `GetExampleItemUseCase`.
- **`:app`**: `MainActivity` hosts a single `NavDisplay(backStack, entryDecorators = [saveableStateHolder, viewModelStore], entryProvider { … })`; a list-row tap pushes `ExampleDetailRoute(item.id)`; back pops the stack.
- **Docs**: `ARCHITECTURE.md` Navigation section rewritten for Nav3 (was Nav2 `NavHost`); `CLAUDE.md` + `README` nav-3 references updated to reflect the shipped graph.

## Design notes
- **App owns the back stack** (Nav3 model); features contribute `NavKey`s + screen composables. The `entryProvider` lives in `:app` — the one module that knows every feature.
- Feature `api`-exposes `navigation3-runtime` so `:app` sees the route types as `NavKey`.
- The feature's `@HiltAndroidTest` graph now includes the assisted `ExampleDetailViewModel`; the test-only `FakeDataModule` provides the repository so graph validation passes without `:core-data`.

## Verification (local)
`:app:assembleDebug` ✅ (full Nav3 + assisted-inject Hilt graph + serialization) · `test` ✅ · instrumented tests compile + `hiltJavaCompileDebugAndroidTest` ✅ · `spotlessCheck`/`lintRelease` ✅ · `moduleGraph` unchanged (no new module edges). Full instrumented suite runs on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)