### PR TITLE
chore(agp): drop deprecated AGP 9 default-preservation flags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,14 +35,20 @@ org.gradle.caching=true
 # as $YEAR so spotlessApply rewrites the current year on demand.
 template.company=MyCompany
 template.licenseYear=$YEAR
-# AGP 9 transition: the four flags listed by the agp-9-upgrade skill
-# (`builtInKotlin`, `newDsl`, `uniquePackageNames`, `enableAppCompileTimeRClass`)
-# have been removed now that the migration is complete. The remaining
-# AGP 9 default-preservation flags below stay until each new behavior
-# is explicitly validated in a follow-up bump.
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.usesSdkInManifest.disallowed=false
-android.dependency.useConstraints=true
+# AGP 9 migration flags. The initial set (builtInKotlin, newDsl,
+# uniquePackageNames, enableAppCompileTimeRClass) was removed once the
+# migration completed. AGP 9.3.1 then deprecated the default-preservation
+# flags, so this follow-up drops them and takes the new AGP 9 defaults:
+# resValues off (no module uses resValue()), targetSdk defaults to compileSdk
+# (we set targetSdk explicitly anyway), uses-sdk-in-manifest disallowed (we use
+# the DSL), dependency constraints off (also clears the library-constraints
+# import warning), and optimized resource shrinking on. Validated with
+# assembleRelease + the full test suite.
+#
+# strictFullModeForKeepRules stays: its new default (true) lets R8 drop
+# implicitly-kept default constructors, which needs a keep-rule audit first.
+# Revisit before AGP 10 removes the flag.
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Clears the 5 build warnings from AGP 9.3.1 (screenshots from the IDE build). Four are deprecated `android.*` project options; the fifth is the library-constraints import advisory.

These were the "default-preservation flags" kept during the AGP 9 migration, with a comment saying they stay "until each new behavior is explicitly validated in a follow-up bump." This is that follow-up. Per the AGP 9.0 release notes (agp-9-upgrade skill), each is safe to drop here:

| Flag dropped | New default taken | Why it is safe |
|---|---|---|
| `defaults.buildfeatures.resvalues=true` | resValues off | no module calls `resValue(...)` |
| `sdk.defaultTargetSdkToCompileSdkIfUnset=false` | targetSdk defaults to compileSdk | we set `targetSdk = 37` explicitly |
| `usesSdkInManifest.disallowed=false` | uses-sdk in manifest disallowed | we configure SDKs via the DSL, no manifest `uses-sdk` |
| `dependency.useConstraints=true` | constraints off | also clears the `excludeLibraryComponentsFromConstraints` import warning and speeds up import |
| `r8.optimizedResourceShrinking=false` | optimized resource shrinking on | keep rules are complete; `assembleRelease` verified |

Kept `android.r8.strictFullModeForKeepRules=false`: it is not deprecated yet, and its new default lets R8 drop implicitly-kept default constructors, which needs a keep-rule audit first. Comment updated to say so.

Also keeps `org.gradle.tooling.parallel=true` (faster Gradle 9.4+ IDE sync).

## Verify
All 5 warnings gone. `:app:assembleRelease` + full `test` green locally. Full CI on this PR.