### PR TITLE
docs: refresh dependency/ignore notes after recent maintenance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ConsultMe is a **Jetpack Compose template** for new Android apps — multi-module, Kotlin-only, with code-quality plumbing (Spotless + ktlint, Android Lint) wired in. Apps generated from this template start by replacing the placeholder content in `:feature-example` (see README.md "How to Rename and Refactor"). Default package is `com.thecompany.consultme` and is expected to be renamed downstream.
 
-**Roadmap and ongoing improvements** live in `docs/IMPROVEMENT_PLAN.md`. Check it before starting non-trivial work — phases 0–10 are done (archived at the bottom of that doc); the top lists recent work, what's currently deferred/blocked (Kotlin 2.4.x, KSP 2.3.10 — both pinned in `dependabot.yml`), and unscheduled quality bets.
+**Roadmap and ongoing improvements** live in `docs/IMPROVEMENT_PLAN.md`. Check it before starting non-trivial work. Phases 0-10 are done (archived at the bottom of that doc); the top lists recent work, what's currently deferred/blocked (Kotlin 2.4.x, and KSP 2.3.10/2.3.11, both pinned in `dependabot.yml`), and unscheduled quality bets.
 
 ## Common commands
 
@@ -58,9 +58,12 @@ Lint baselines (`<module>/lint-baseline.xml`) exist per module; regenerate with 
 
 All versions live in `gradle/libs.versions.toml`. Dependabot is enabled with grouped updates (`androidx`, `kotlin-and-coroutines`, `gradle-and-plugins`, `jetpack-compose`, `testing-libs`).
 
-Active ignore rules in `.github/dependabot.yml` — leave these alone unless doing the corresponding migration:
+Active ignore rules in `.github/dependabot.yml`, with rationale in that file and in `docs/IMPROVEMENT_PLAN.md`. Leave them alone unless doing the corresponding migration:
 
-- All AGP-major and Hilt 2.59+ ignore entries lifted in Phase 9 (AGP 9.2.1 / Hilt 2.59.2 are live now). Future major-version migrations get their own dedicated-PR pin again on a case-by-case basis.
+- `com.google.devtools.ksp*` at `2.3.10` and `2.3.11`: both break androidTest KSP output (Hilt test-component codegen fails). Tracked upstream at google/ksp#3050. The list names known-broken versions only, so Dependabot still surfaces 2.3.12+.
+- `org.jetbrains.kotlin* >= 2.4.0`: Kotlin 2.4 is a coordinated kotlin + ksp + hilt migration, still blocked on KSP (no 2.4.x line), Hilt metadata, and CodeQL. Tracked in issue #185.
+
+The Phase 9 AGP-major and Hilt 2.59+ ignores were lifted once that migration landed. Future major-version migrations get their own dedicated-PR pin case by case.
 
 ## Recommended Claude Code skills
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -28,7 +28,8 @@ Feature and hygiene work since `v4.1.x`, outside the numbered phases:
 
 - **End-to-end vertical slice** (#227) — populated the previously-empty domain/data layers with one canonical ports-&-adapters slice: `ExampleItem` (`:core-model`) → Room DAO (`:core-database`) → `ExampleRepository` port (`:core-domain`) / `DefaultExampleRepository` adapter (`:core-data`) → `GetExampleItemsUseCase` → `ExampleViewModel`. Replaced placeholder test stubs with real per-layer tests, and reconciled `ARCHITECTURE.md` with the actual module graph.
 - **Navigation 3** (#229) — migrated `:app` off the (declared-but-unused) Nav2 `navigation-compose` to Navigation 3 (stable `1.1.4`): app-owned `NavDisplay`, `@Serializable` `NavKey` routes owned by features, and a list→detail flow whose detail ViewModel uses Hilt assisted injection for the route argument.
-- **Dependency maintenance** — AGP 9.3.0 (#222), Hilt 2.60.1 (#214), kover 0.9.9 + spotless 8.8.0 (#224), plus the roborazzi / uiautomator / androidx / github-actions Dependabot groups.
+- **Dependency maintenance**: AGP 9.3.1, Hilt 2.60.1, Kover 0.9.9, Spotless 8.9.0, Roborazzi 1.70.0, kotlinx-serialization-core 1.11.0, androidx baselineprofile/benchmark 1.5.0-beta01, plus the testing and github-actions Dependabot groups.
+- **AGP 9 flag follow-up and lint cleanup** (#250, #251): dropped the deprecated AGP 9 default-preservation flags and took the new defaults (optimized resource shrinking on, resValues off, dependency constraints off), leaving only `android.r8.strictFullModeForKeepRules=false` pending a keep-rule audit. Removed the unused Android Studio wizard colors from `:app` and disabled the dependency-version lint checks (Dependabot owns versions), so the per-module lint baselines are now empty.
 
 ## Deferred / blocked
 


### PR DESCRIPTION
Brings the docs in line with the current state after the recent maintenance.

- **CLAUDE.md**: the "active ignore rules" bullet still only described the lifted Phase 9 ignores. Replaced it with the current holds: `com.google.devtools.ksp*` at 2.3.10 and 2.3.11 (google/ksp#3050) and `org.jetbrains.kotlin* >= 2.4.0` (issue #185). Also fixed the stale "KSP 2.3.10" mention in the roadmap pointer.
- **docs/IMPROVEMENT_PLAN.md**: updated the dependency-maintenance line to current versions and recorded the AGP 9 flag follow-up + lint cleanup (#250, #251).

Docs only.